### PR TITLE
Add OSX deployment target

### DIFF
--- a/Cleanse.podspec
+++ b/Cleanse.podspec
@@ -8,4 +8,5 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/square/Cleanse.git', :tag => s.version }
   s.source_files = 'Cleanse/*.swift'
   s.ios.deployment_target = '8.1'
+  s.osx.deployment_target = '10.10'
 end


### PR DESCRIPTION
Cleanse doesn't appear to have any iOS specific dependencies. It'd be nice to be able to pull it in (via CocoaPods) for OSX projects as well.