### PR TITLE
Fix ScopedBindingDecorator conformation to BindingBuilder

### DIFF
--- a/Cleanse/ScopedBindingDecorator.swift
+++ b/Cleanse/ScopedBindingDecorator.swift
@@ -12,6 +12,8 @@ import Foundation
 public struct ScopedBindingDecorator<Wrapped: BindingBuilder, S: _ScopeBase> : BindingBuilderDecorator {
     public typealias MaybeScope = S
 
+    public typealias FinalProvider = Wrapped.FinalProvider
+
     public let wrapped: Wrapped
     
     public init(wrapped: Wrapped) {


### PR DESCRIPTION
I tried to use Cleanse from master branch, but it gave me compilation error.