### PR TITLE
Swift 4 Support

### DIFF
--- a/Cleanse.xcodeproj/project.pbxproj
+++ b/Cleanse.xcodeproj/project.pbxproj
@@ -741,7 +741,7 @@
 				OTHER_SWIFT_FLAGS = "-DSUPPORT_LEGACY_OBJECT_GRAPH";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -788,7 +788,7 @@
 				OTHER_SWIFT_FLAGS = "-DSUPPORT_LEGACY_OBJECT_GRAPH";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/Cleanse/LegacyObjectGraph.swift
+++ b/Cleanse/LegacyObjectGraph.swift
@@ -10,14 +10,14 @@ import Foundation
 
 #if SUPPORT_LEGACY_OBJECT_GRAPH
 
-typealias LegacyProviderProvider = (AnyClass, String?) -> (Void) -> AnyObject
+typealias LegacyProviderProvider = (AnyClass, String?) -> ()-> AnyObject
 typealias LegacyPropertyInjectorProvider = (AnyClass) -> (AnyObject) -> Void
 
 /// Protocol with base method for LegacyObjectGraph
 public protocol LegacyObjectGraphProtocol {
     
     /// Core method that all legacy methods are based off of. This returns a function that when evaluated it will emit the instance registered for `cls`
-    func providerForClass(cls: AnyClass, withName name: String?) -> (Void) -> AnyObject
+    func providerForClass(cls: AnyClass, withName name: String?) -> ()-> AnyObject
 }
 
 /// This is a class to support backwards compatibility for Cleanse's Predecessor, Stiletto.
@@ -36,7 +36,7 @@ public protocol LegacyObjectGraphProtocol {
     }
     
     /// Convenience method equivalent to `providerForClass(cls: cls, withName: nil)`
-    @objc(providerForClass:) public func providerForClass(cls: AnyClass) -> (Void) -> AnyObject {
+    @objc(providerForClass:) public func providerForClass(cls: AnyClass) -> ()-> AnyObject {
         return providerForClass(cls: cls, withName: nil)
     }
     
@@ -45,7 +45,7 @@ public protocol LegacyObjectGraphProtocol {
         return providerForClass(cls: cls, withName: name)()
     }
     
-    @objc public func providerForClass(cls: AnyClass, withName name: String?) -> (Void) -> AnyObject {
+    @objc public func providerForClass(cls: AnyClass, withName name: String?) -> ()-> AnyObject {
         return graph.legacyProvider(cls: cls, name:  name).get
     }
     

--- a/Cleanse/Provider.swift
+++ b/Cleanse/Provider.swift
@@ -17,7 +17,7 @@ public protocol ProviderProtocol {
     
     init<P: ProviderProtocol>(other: P) where P.Element == Element
     init(value: Element)
-    init(getter: @escaping (Void) -> Element)
+    init(getter: @escaping ()-> Element)
 
     /// - returns: provides an instance of `Element`
     func get() -> Element
@@ -44,7 +44,7 @@ protocol AnyProvider {
     /// Of type Provider<() -> Element>
     var anyGetterProvider: AnyProvider? { get }
     
-    static func makeNew(getter: @escaping (Void) -> Any) -> AnyProvider
+    static func makeNew(getter: @escaping ()-> Any) -> AnyProvider
 
     func asCheckedProvider<Element>(_ type: Element.Type) -> Provider<Element>
     

--- a/Cleanse/ValidationVisitor.swift
+++ b/Cleanse/ValidationVisitor.swift
@@ -341,7 +341,7 @@ final class ValidationVisitor : ComponentVisitor {
         }
 
         errors.sort {
-            return $0.0.description < $0.1.description
+            return $0.description < $1.description
         }
 
         switch errors.count {


### PR DESCRIPTION
v4 includes stronger type-safety for tuples so `(Void) -> ...` should be `() -> ...` and multi-parameter closures cannot be wrapped into tuples anymore.