### PR TITLE
Swift 4.2 Support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 # cache: bundler
 language: objective-c
 
-osx_image: xcode9.3
+osx_image: xcode10
 xcode_project: Cleanse.xcodeproj
 xcode_scheme: Cleanse
-xcode_sdk: iphonesimulator11.3
+xcode_sdk: iphonesimulator12.0
 
 script:
   - xcodebuild test -project $TRAVIS_XCODE_PROJECT -scheme $TRAVIS_XCODE_SCHEME -sdk $TRAVIS_XCODE_SDK -enableCodeCoverage=YES -destination "platform=iOS Simulator,name=iPad Air 2"

--- a/Cleanse.xcodeproj/project.pbxproj
+++ b/Cleanse.xcodeproj/project.pbxproj
@@ -668,7 +668,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -690,7 +690,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -741,7 +741,7 @@
 				OTHER_SWIFT_FLAGS = "-DSUPPORT_LEGACY_OBJECT_GRAPH";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -788,7 +788,7 @@
 				OTHER_SWIFT_FLAGS = "-DSUPPORT_LEGACY_OBJECT_GRAPH";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -812,7 +812,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -831,7 +831,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.squareup.Cleanse;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -843,7 +843,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.squareup.CleanseTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -855,7 +855,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.squareup.CleanseTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/Cleanse.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Cleanse.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Cleanse/CanonicalRepresentable.swift
+++ b/Cleanse/CanonicalRepresentable.swift
@@ -30,13 +30,19 @@ extension CanonicalRepresentable {
     }
 }
 
+// XC 9 Support. In XC 10, ImplicitlyUnwrappedOptional is removed in Swift v4.2. There is a source break
+// during compatibility mode when compiling swift 3 code that also makes the compiler think that the
+// ImplicitlyUnwrappedOptional has been renamed to Optional. Swift v4.2 (XC 10) during compatibility mode
+// interprets swift 3 code as swift v3.4. For XC 9 and below (where ImplicitlyUnwrappedOptional still exists),
+// Swift 4 in compatibility mode inteprets swift 3 code as swift v3.3 and below. Hence, #if !swift(>=3.4).
+#if !swift(>=3.4)
 extension ImplicitlyUnwrappedOptional : CanonicalRepresentable {
     typealias Canonical = Wrapped
-
     static func transformFromCanonicalCanonical(canonical: Wrapped) -> ImplicitlyUnwrappedOptional {
         return canonical
     }
 }
+#endif
 
 extension Optional : CanonicalRepresentable {
     typealias Canonical = Wrapped
@@ -57,12 +63,3 @@ extension Optional : CanonicalRepresentable {
     }
     
 #endif
-
-//extension Provider : CanonicalRepresentable {
-//    public typealias Canonical = Element
-//    
-//    
-//    static func transformFromCanonicalCanonical(canonical canonical: Element) -> Provider {
-//        return Provider(value: canonical)
-//    }
-//}


### PR DESCRIPTION
The `ImplicitlyUnwrappedOptional` type was removed in swift v4.2 (https://github.com/apple/swift-evolution/blob/master/proposals/0212-compiler-version-directive.md).