### PR TITLE
Add default Singleton Scope.

### DIFF
--- a/Cleanse.podspec
+++ b/Cleanse.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Cleanse'
-  s.version  = '4.2.1'
+  s.version  = '4.2.2'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Lightweight Swift Dependency Injection Framework'
   s.homepage = 'https://github.com/square/Cleanse'

--- a/Cleanse/Scope.swift
+++ b/Cleanse/Scope.swift
@@ -23,6 +23,10 @@ public protocol Scope : _ScopeBase {
 public struct Unscoped : _ScopeBase {
 }
 
+/// Default provided scope for the consumer to use in the Root Component. One does not have to use this scope
+/// and may use their own in the root component, but this is provided for convenience.
+public struct Singleton : Scope {}
+
 extension _ScopeBase {
 
     // Returns our metatype if we're not `Unscoped`


### PR DESCRIPTION
This is provided for convenience and the consumer isn't required to use this scope at all. Including this because we reference the `Singleton` scope for bindings that are shared across the entire object graph. This should help decrease confusion for new consumers learning how to set up their project.