### PR TITLE
Remove class requirement for Weak Providers.

### DIFF
--- a/Cleanse/WeakProvider.swift
+++ b/Cleanse/WeakProvider.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct WeakProvider<E: AnyObject> : ProviderProtocol {
+public struct WeakProvider<E> : ProviderProtocol {
     public typealias Element = E?
 
     fileprivate let getter: () -> Element


### PR DESCRIPTION
The `AnyObject` requirement means we can only use it on class types and not protocol or struct types.