### PR TITLE
Retain a strong reference to all Future Providers.

### DIFF
--- a/Cleanse/Graph.swift
+++ b/Cleanse/Graph.swift
@@ -96,15 +96,8 @@ class Graph : BinderBase {
         }
 
         requirements[key] = (requirements[key] ?? []) + [debugInfo]
-
-        if type is AnyWeakProvider.Type {
-            return Provider(value: type.makeNew(getter: { [weak futureProvider] in
-                 futureProvider?.getAny() as Any
-            }) as! Element)
-        } else {
-            return Provider(value: type.makeNew(getter: { futureProvider.getAny() }) as! Element)
-        }
         
+        return Provider(value: type.makeNew(getter: { futureProvider.getAny() }) as! Element)
     }
 
     private func addProvider(provider: AnyProvider) {


### PR DESCRIPTION
If the type was of a `AnyWeakProvider` type, then we would only retain a weak reference to its `FutureProvider` instance causing it to become deallocated. We want to retain a strong reference to this `FutureProvider` like we do for normal providers because we still need to be able to acquire an instance of its getter.