### PR TITLE
Fix the Package.swift file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,15 @@
+// swift-tools-version:4.0
+
 import PackageDescription
 
 let package = Package(
     name: "Cleanse",
+    products: [
+        .library(name: "Cleanse", targets: ["Cleanse"]),
+    ],
+    dependencies: [],
     targets: [
+        .target(name: "Cleanse", dependencies: [], path: "Cleanse"),
     ]
 )
 


### PR DESCRIPTION
Xcode failes to import dependency if using the old Package.swift