### PR TITLE
Retain subcomponent graphs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,7 @@
   [#112](https://github.com/square/Cleanse/issues/112)
 
 #### Bug Fixes
+
+* Retain subcomponent graphs  
+  [Sebastian Shanus](https://github.com/sebastianv1)
+  [#42](https://github.com/square/Cleanse/issues/42)

--- a/Cleanse.xcodeproj/project.pbxproj
+++ b/Cleanse.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		DCE9318223220ED800C0522F /* AssistedInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE9318123220ED800C0522F /* AssistedInjection.swift */; };
 		DCE93184232212BA00C0522F /* AssistedInjectionArities.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE93183232212BA00C0522F /* AssistedInjectionArities.swift */; };
 		DCE931862322175800C0522F /* AssistedInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE931852322175800C0522F /* AssistedInjectionTests.swift */; };
+		DCFC812F23A8687B00629D44 /* SubcomponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCFC812E23A8687B00629D44 /* SubcomponentTests.swift */; };
 		F61133BF1CD41EE600069972 /* TypeKeyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61133BE1CD41EE600069972 /* TypeKeyProtocol.swift */; };
 		F61133C11CD7B36600069972 /* MemoryManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61133C01CD7B36600069972 /* MemoryManagementTests.swift */; };
 		F61133C51CD7B5A900069972 /* RootComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61133C41CD7B5A900069972 /* RootComponent.swift */; };
@@ -118,6 +119,7 @@
 		DCE9318123220ED800C0522F /* AssistedInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistedInjection.swift; sourceTree = "<group>"; };
 		DCE93183232212BA00C0522F /* AssistedInjectionArities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssistedInjectionArities.swift; sourceTree = "<group>"; };
 		DCE931852322175800C0522F /* AssistedInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistedInjectionTests.swift; sourceTree = "<group>"; };
+		DCFC812E23A8687B00629D44 /* SubcomponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubcomponentTests.swift; sourceTree = "<group>"; };
 		F61133BE1CD41EE600069972 /* TypeKeyProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeKeyProtocol.swift; sourceTree = "<group>"; };
 		F61133C01CD7B36600069972 /* MemoryManagementTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemoryManagementTests.swift; sourceTree = "<group>"; };
 		F61133C41CD7B5A900069972 /* RootComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootComponent.swift; sourceTree = "<group>"; };
@@ -440,6 +442,7 @@
 				88A8D19A1E81D52A00F15A75 /* TaggedProviderTests.swift */,
 				DCE931852322175800C0522F /* AssistedInjectionTests.swift */,
 				DC8ACA80238315EB005A6F51 /* SPITests.swift */,
+				DCFC812E23A8687B00629D44 /* SubcomponentTests.swift */,
 			);
 			path = CleanseTests;
 			sourceTree = "<group>";
@@ -703,6 +706,7 @@
 				F6A82B811CE2F182007C3A32 /* DebuggingTests.swift in Sources */,
 				F6A660DA1CCB07C3004DD6E3 /* CleanseTests.swift in Sources */,
 				F6A82B7D1CE2858B007C3A32 /* LegacyObjectGraphTests.swift in Sources */,
+				DCFC812F23A8687B00629D44 /* SubcomponentTests.swift in Sources */,
 				F61191361CD30B3300686C0C /* ErrorTest.swift in Sources */,
 				F6FA735A1E2032F90038D8F8 /* ReceiptBindingTests.swift in Sources */,
 				F6AB45151CD9D1F90021AF36 /* NoopVisitor.swift in Sources */,

--- a/Cleanse/ComponentFactory.swift
+++ b/Cleanse/ComponentFactory.swift
@@ -14,17 +14,22 @@ public protocol ComponentFactoryProtocol {
     func build(_ seed: ComponentElement.Seed) -> ComponentElement.Root
 }
 
-public struct ComponentFactory<C: ComponentBase> : ComponentFactoryProtocol {
+public final class ComponentFactory<C: ComponentBase> : ComponentFactoryProtocol {
     public typealias ComponentElement = C
-    fileprivate let factoryFunction: (_ seed: ComponentElement.Seed) -> C.Root
+    fileprivate let factoryFunction: (_ seed: ComponentElement.Seed, _ subgraph: Graph) -> C.Root
+    fileprivate let parent: Graph?
+    fileprivate var subgraphs: [Graph] = []
 
-    init(factoryFunction: @escaping (_ seed: ComponentElement.Seed) -> C.Root) {
+    init(parent: Graph?, factoryFunction: @escaping (_ seed: ComponentElement.Seed, _ subgraph: Graph) -> C.Root) {
         self.factoryFunction = factoryFunction
+        self.parent = parent
     }
 
     /// Builds the Component and returns its root object.
     public func build(_ seed: ComponentElement.Seed) -> ComponentElement.Root {
-        return factoryFunction(seed)
+        let subgraph = Graph(scope: C.Scope.scopeOrNil, parent: parent)
+        subgraphs.append(subgraph)
+        return factoryFunction(seed, subgraph)
     }
 }
 

--- a/Cleanse/Graph.swift
+++ b/Cleanse/Graph.swift
@@ -274,13 +274,9 @@ class Graph : BinderBase {
     }
 
     private func install<C: ComponentBase>(componentBase dependency: C.Type) {
-        // TODO: validate subcomponents
         self.bind(ComponentFactory<C>.self)
             .to(factory: { [weak self] in
-                let `self` = self!
-                return ComponentFactory { seed in
-                    let subgraph = Graph(scope: C.Scope.scopeOrNil, parent: self)
-
+                return ComponentFactory(parent: self) { seed, subgraph in
                     // If the seeds a provider we need to bind it differently
                     if let seed = seed as? AnyProvider {
                         subgraph._internalBind(binding: RawProviderBinding(

--- a/CleanseTests/SubcomponentTests.swift
+++ b/CleanseTests/SubcomponentTests.swift
@@ -1,0 +1,64 @@
+//
+//  SubcomponentTests.swift
+//  CleanseTests
+//
+//  Created by Sebastian Edward Shanus on 12/16/19.
+//  Copyright © 2019 Square, Inc. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import Cleanse
+
+struct A {
+    let b: Provider<B>
+}
+
+struct B {
+    let subcomponent: ComponentFactory<SubComponent>
+}
+
+struct RootType {
+    let a: A
+}
+
+struct Subroot {
+    let name: String
+}
+
+struct AppRootComponent: RootComponent {
+    static func configure(binder: Binder<Unscoped>) {
+        binder.install(dependency: SubComponent.self)
+        binder.bind(A.self).to(factory: A.init)
+        binder.bind(B.self).to(factory: B.init)
+    }
+    
+    static func configureRoot(binder bind: ReceiptBinder<RootType>) -> BindingReceipt<RootType> {
+        return bind.to(factory: RootType.init)
+    }
+    
+    typealias Root = RootType
+}
+
+struct SubComponent: Component {
+    static func configure(binder: Binder<Unscoped>) {
+        binder
+            .bind(String.self)
+            .to(value: "Hello")
+    }
+    
+    static func configureRoot(binder bind: ReceiptBinder<Subroot>) -> BindingReceipt<Subroot> {
+        return bind.to(factory: Subroot.init)
+    }
+    
+    typealias Root = Subroot
+}
+
+
+class SubcomponentTests: XCTestCase {
+    func testNestedSubcomponents() {
+        let root = try! ComponentFactory.of(AppRootComponent.self).build(())
+        let subcomponent = root.a.b.get().subcomponent.build(())
+        XCTAssert(subcomponent.name == "Hello")
+    }
+}

--- a/README.rst
+++ b/README.rst
@@ -170,11 +170,17 @@ Now, let's create our ``RootViewController`` class
 
 We've successfully wired up our root component! Our root object ``RootViewController`` is configured properly, so in our App Delegate we can now `build` the component (and graph) to use it.
 
+**Important**: It is important that you retain an instance of the `ComponentFactory<E>` returned from `ComponentFactory.of(:)`. Otherwise subcomponents may unexpectedly become deallocated.
+
 .. code-block:: swift
+
+    // IMPORTANT: We must retain an instance of our `ComponentFactory`.
+    var factory: ComponentFactory<AppDelegate.Component>?
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Build our root object in our graph.
-        let rootViewController = try! ComponentFactory.of(AppDelegate.Component.self).build(())
+        factory = try! ComponentFactory.of(AppDelegate.Component.self)
+        let rootViewController = factory!.build(())
 
         // Now we can use the root object in our app.
         window!.rootViewController = rootViewController


### PR DESCRIPTION
Subcomponents today are fairly buggy. `Graph` instances that are required to construct subcomponents cause exceptions on `build(:)`. In order to fix this, we need something to retain `Graph` object instances.

This change puts the retention responsibility on `ComponentFactory`. `ComponentFactory` is now responsible for retaining all live instances of subgraphs (aka subcomponents) that it creates via the `build(:)` function. Subgraphs will be deinitialized alongside `ComponentFactory`.