### PR TITLE
Xcode 11.2 Support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ Carthage/
 
 # Cocoapods
 gen/
+
+# Swift PM
+.swiftpm

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "self:">
-   </FileRef>
-</Workspace>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 # cache: bundler
 language: objective-c
 
-osx_image: xcode10.2
+osx_image: xcode11.2
 xcode_project: Cleanse.xcodeproj
 xcode_scheme: Cleanse
-xcode_sdk: iphonesimulator12.2
+xcode_sdk: iphonesimulator13.2
 
 jobs:
   include:
     - stage: Test
-      script: xcodebuild test -project $TRAVIS_XCODE_PROJECT -scheme $TRAVIS_XCODE_SCHEME -sdk $TRAVIS_XCODE_SDK -enableCodeCoverage=YES -destination "platform=iOS Simulator,name=iPad Air 2"
-    - stage: Build Sample Project
-      script: xcodebuild build -project Examples/CleanseGithubBrowser/CleanseGithubBrowser.xcodeproj -scheme CleanseGithubBrowser -sdk $TRAVIS_XCODE_SDK
+      script: xcodebuild test -project $TRAVIS_XCODE_PROJECT -scheme $TRAVIS_XCODE_SCHEME -sdk $TRAVIS_XCODE_SDK -enableCodeCoverage=YES -destination "platform=iOS Simulator,name=iPhone 8"
+    - stage: Build & Test Sample Project
+      script: xcodebuild test -project Examples/CleanseGithubBrowser/CleanseGithubBrowser.xcodeproj -scheme CleanseGithubBrowser -sdk $TRAVIS_XCODE_SDK -destination "platform=iOS Simulator,name=iPhone 8"
 
 before_install:
   - rvm use $RVM_RUBY_VERSION

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Master
 
-#### Features
+#### Features & Updates
+
+* Xcode 11.2 Support  
+  [Sebastian Shanus](https://github.com/sebastianv1)
+  [#125](https://github.com/square/Cleanse/issues/125)
 
 * Service Provider Interface (SPI)  
   [Sebastian Shanus](https://github.com/sebastianv1)

--- a/Cleanse/Factory.swift
+++ b/Cleanse/Factory.swift
@@ -10,6 +10,10 @@ import Foundation
 
 public struct Factory<Tag: AssistedFactory> {
     let factory: (Tag.Seed) -> Tag.Element
+    public init(factory: @escaping (Tag.Seed) -> Tag.Element) {
+        self.factory = factory
+    }
+    
     public func build(_ seed: Tag.Seed) -> Tag.Element {
         return factory(seed)
     }

--- a/Examples/CleanseGithubBrowser/CleanseGithubBrowser.xcodeproj/project.pbxproj
+++ b/Examples/CleanseGithubBrowser/CleanseGithubBrowser.xcodeproj/project.pbxproj
@@ -651,7 +651,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.squareup.CleanseGithubBrowserTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CleanseGithubBrowser.app/CleanseGithubBrowser";
 			};
 			name = Debug;
@@ -664,7 +664,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.squareup.CleanseGithubBrowserTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CleanseGithubBrowser.app/CleanseGithubBrowser";
 			};
 			name = Release;
@@ -676,7 +676,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.squareup.CleanseGithubBrowserUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = CleanseGithubBrowser;
 			};
 			name = Debug;
@@ -688,7 +688,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.squareup.CleanseGithubBrowserUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = CleanseGithubBrowser;
 			};
 			name = Release;

--- a/Examples/CleanseGithubBrowser/CleanseGithubBrowser.xcodeproj/xcshareddata/xcschemes/CleanseGithubBrowser.xcscheme
+++ b/Examples/CleanseGithubBrowser/CleanseGithubBrowser.xcodeproj/xcshareddata/xcschemes/CleanseGithubBrowser.xcscheme
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F6C9F3581D0BD01700877D0B"
+               BuildableName = "CleanseGithubBrowser.app"
+               BlueprintName = "CleanseGithubBrowser"
+               ReferencedContainer = "container:CleanseGithubBrowser.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F6C9F3581D0BD01700877D0B"
+            BuildableName = "CleanseGithubBrowser.app"
+            BlueprintName = "CleanseGithubBrowser"
+            ReferencedContainer = "container:CleanseGithubBrowser.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F6C9F36C1D0BD01700877D0B"
+               BuildableName = "CleanseGithubBrowserTests.xctest"
+               BlueprintName = "CleanseGithubBrowserTests"
+               ReferencedContainer = "container:CleanseGithubBrowser.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F6C9F3771D0BD01700877D0B"
+               BuildableName = "CleanseGithubBrowserUITests.xctest"
+               BlueprintName = "CleanseGithubBrowserUITests"
+               ReferencedContainer = "container:CleanseGithubBrowser.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F6C9F3581D0BD01700877D0B"
+            BuildableName = "CleanseGithubBrowser.app"
+            BlueprintName = "CleanseGithubBrowser"
+            ReferencedContainer = "container:CleanseGithubBrowser.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F6C9F3581D0BD01700877D0B"
+            BuildableName = "CleanseGithubBrowser.app"
+            BlueprintName = "CleanseGithubBrowser"
+            ReferencedContainer = "container:CleanseGithubBrowser.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/CleanseGithubBrowser/CleanseGithubBrowserTests/CleanseGithubBrowserTests.swift
+++ b/Examples/CleanseGithubBrowser/CleanseGithubBrowserTests/CleanseGithubBrowserTests.swift
@@ -14,10 +14,13 @@ import Cleanse
 class CleanseGithubBrowserTests: XCTestCase {
     func testMembersViewController_Title() {
         // Tests that the member's view controller sets the title appropriately.
+        let factory = Factory<AssistedInjectionTags.MembersPageSettingsSeed> { _ in
+            return MembersPageSettings()
+        }
         let vc = MembersViewController(
             memberService: FakeGithubMembersService(),
             githubOrganizationName: .init(value: "Organiztion Name"),
-            settings: MembersPageSettings()
+            settings: factory
         )
 
         XCTAssertEqual(vc.navigationItem.title, "Members of Organiztion Name")


### PR DESCRIPTION
* Exposes public `factory` function for assisted injection `Factory` class. This is similar to `Provider` and other core primitives to allow for manual testing.
* Tests for the sample project weren't being run (or built). Change travis CI config to build and test the sample project.
* Bump TravisCI to Xcode 11.2.