### PR TITLE
Fix WeakProviders becoming deinitialized.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 #### Bug Fixues
 
-* None
+* Fix `WeakProviders` becoming deinitialized.  
+  [Sebastian Shanus](https://github.com/sebastianv1)
+  [#98](https://github.com/square/Cleanse/issues/98)
 
 ## 4.2.5
 

--- a/Cleanse/Graph.swift
+++ b/Cleanse/Graph.swift
@@ -258,8 +258,6 @@ class Graph : BinderBase {
         for (k,v) in self.futureProviders {
             v.resolve(actualProvider: getRegisteredProvider(key: k)!)
         }
-
-        self.futureProviders.removeAll()
         
         finalized = true
     }


### PR DESCRIPTION
Upon a `Graph` instance's `finalize` function, we clear out the dictionary of `futureProviders`. The dictionary holds all instances of `FutureProvider`s that represent a type whose factory instance may not have been created yet. When we create the correct `Provider` instance inside our graph, it retains a strong reference to the `FutureProvider` instance, so even though we clear out the dictionary after `finalize`, these instances are still in memory as they are being retained by their equivalent `Provider` instances.

This poses an issue for `WeakProvider`s as their wrapped `Provider` instance rightfully holds onto a `weak` instance of the `FutureProvider`. Therefore, if no other `Provider` retains its equivalent `FutureProvider`, it will be deinitialized and all `WeakProvider`s for a type will return `nil`.

This one line change deletes the call to clear out the dictionary of `FutureProvider`s after `finalize`. The existing implementation only allows us to build a graph once and will throw an error if we try to mutate a graph after construction. This is validated using the `finalized` boolean stored internally. Subcomponents all construct and finalize their own `Graph` instances, and don't reuse existing `futureProvider` dictionaries. Thus, it doesn't seem that keeping the objects stored inside the dictionary will cause any functional changes, and we already know that we won't be causing any extra memory overhead as existing functionality today already retains all `FutureProvider` instances.