### PR TITLE
Implement Linker Step

### DIFF
--- a/cleansec/CleansecFramework/Linking/LinkedComponent.swift
+++ b/cleansec/CleansecFramework/Linking/LinkedComponent.swift
@@ -1,0 +1,20 @@
+//
+//  LinkedComponent.swift
+//  CleansecFramework
+//
+//  Created by Sebastian Edward Shanus on 5/12/20.
+//  Copyright © 2020 Square. All rights reserved.
+//
+
+import Foundation
+
+/// `Cleanse.Component` representation with all linked providers.
+public struct LinkedComponent {
+    public let type: String
+    public let rootType: String
+    public let providers: [StandardProvider]
+    public let seed: String
+    public let includedModules: [String]
+    public let subcomponents: [String]
+    public let isRoot: Bool
+}

--- a/cleansec/CleansecFramework/Linking/LinkedInterface.swift
+++ b/cleansec/CleansecFramework/Linking/LinkedInterface.swift
@@ -1,0 +1,15 @@
+//
+//  LinkedInterface.swift
+//  CleansecFramework
+//
+//  Created by Sebastian Edward Shanus on 5/12/20.
+//  Copyright © 2020 Square. All rights reserved.
+//
+
+import Foundation
+
+/// Representation of all components and modules with their providers linked.
+public struct LinkedInterface {
+    public let components: [LinkedComponent]
+    public let modules: [LinkedModule]
+}

--- a/cleansec/CleansecFramework/Linking/LinkedModule.swift
+++ b/cleansec/CleansecFramework/Linking/LinkedModule.swift
@@ -1,0 +1,17 @@
+//
+//  LinkedModule.swift
+//  CleansecFramework
+//
+//  Created by Sebastian Edward Shanus on 5/12/20.
+//  Copyright © 2020 Square. All rights reserved.
+//
+
+import Foundation
+
+/// `Cleanse.Module` representation with all standard providers and linked reference providers.
+public struct LinkedModule {
+    public let type: String
+    public let providers: [StandardProvider]
+    public let includedModules: [String]
+    public let subcomponents: [String]
+}

--- a/cleansec/CleansecFramework/Linking/Linker.swift
+++ b/cleansec/CleansecFramework/Linking/Linker.swift
@@ -1,0 +1,88 @@
+//
+//  Linker.swift
+//  CleansecFramework
+//
+//  Created by Sebastian Edward Shanus on 5/12/20.
+//  Copyright © 2020 Square. All rights reserved.
+//
+
+import Foundation
+
+/**
+ The Linker is repsonsible for linking `ReferenceProvider` instances to their respective `DanglingProvider`.
+ */
+public struct Linker {
+    /// Links all the reference providers to their dangling providers.
+    ///
+    /// - parameter modules: List of `ModuleRepresentation` instances to link all providers.
+    /// - returns: `LikedInterface` instance with all modules, components, and linked `StandardProvider` instances.
+    ///
+    public static func link(modules: [ModuleRepresentation]) -> LinkedInterface {
+        let files = modules.flatMap { $0.files }
+        return link(files: files)
+    }
+    
+    private static func link(files: [FileRepresentation]) -> LinkedInterface {
+        let components = files.flatMap { $0.components }
+        let modules = files.flatMap { $0.modules }
+        let danglingProviders = components.flatMap { $0.danglingProviders } + modules.flatMap { $0.danglingProviders }
+        let danglingProvidersByReference = danglingProviders.reduce(into: [String:DanglingProvider]()) { (dict, provider) in
+            if let _ = dict[provider.reference] {
+                print("Warning: Duplicate dangling provider reference: \(provider.reference)")
+            }
+            dict[provider.reference] = provider
+        }
+        
+        let linkedComponents = components.map { component -> LinkedComponent in
+            let linkedProviders = link(
+                referenceProviders: component.referenceProviders,
+                danglingProvidersByReference: danglingProvidersByReference
+            )
+            let allProviders = component.providers + linkedProviders
+            return LinkedComponent(
+                type: component.type,
+                rootType: component.rootType,
+                providers: allProviders,
+                seed: component.seed,
+                includedModules: component.includedModules,
+                subcomponents: component.subcomponents,
+                isRoot: component.isRoot
+            )
+        }
+        
+        let linkedModules = modules.map { module -> LinkedModule in
+            let linkedProviders = link(
+                referenceProviders: module.referenceProviders,
+                danglingProvidersByReference: danglingProvidersByReference
+            )
+            let allProviders = module.providers + linkedProviders
+            return LinkedModule(
+                type: module.type,
+                providers: allProviders,
+                includedModules: module.includedModules,
+                subcomponents: module.subcomponents
+            )
+        }
+        
+        return LinkedInterface(
+            components: linkedComponents,
+            modules: linkedModules
+        )
+    }
+    
+    private static func link(referenceProviders: [ReferenceProvider], danglingProvidersByReference: [String:DanglingProvider]) -> [StandardProvider] {
+        return referenceProviders.compactMap { referenceProvider -> StandardProvider? in
+            guard let linked = danglingProvidersByReference[referenceProvider.reference] else {
+                print("Warning: Failed to find pointee for reference provider: \(referenceProvider)")
+                return nil
+            }
+            return StandardProvider(
+                type: referenceProvider.type,
+                dependencies: linked.dependencies,
+                tag: referenceProvider.tag,
+                scoped: referenceProvider.scoped,
+                collectionType: referenceProvider.collectionType
+            )
+        }
+    }
+}

--- a/cleansec/CleansecFrameworkTests/LinkerTests.swift
+++ b/cleansec/CleansecFrameworkTests/LinkerTests.swift
@@ -1,0 +1,133 @@
+//
+//  LinkerTests.swift
+//  CleansecFrameworkTests
+//
+//  Created by Sebastian Edward Shanus on 5/12/20.
+//  Copyright © 2020 Square. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import CleansecFramework
+
+class LinkerTests: XCTestCase {
+    func testLinkingWithModule() {
+        let danglingProvider = DanglingProvider(type: "A", dependencies: [], reference: "reference_id")
+        let referenceProvider = ReferenceProvider(type: "A", tag: nil, scoped: nil, collectionType: nil, reference: "reference_id")
+        let module = Module(
+            type: "Test", providers: [], danglingProviders: [danglingProvider], referenceProviders: [referenceProvider], includedModules: [], subcomponents: [])
+        let file = FileRepresentation(
+            components: [],
+            modules: [module])
+        let moduleRep = ModuleRepresentation(
+            files: [file]
+        )
+        let interface = Linker.link(modules: [moduleRep])
+        XCTAssertEqual(interface.modules.count, 1)
+        XCTAssertEqual(interface.modules.first!.providers.count, 1)
+        XCTAssertEqual(interface.modules.first!.providers.first!, StandardProvider(type: "A", dependencies: [], tag: nil, scoped: nil, collectionType: nil))
+    }
+    
+    func testLinkingAcrossModules() {
+        let danglingProvider = DanglingProvider(type: "A", dependencies: [], reference: "reference_id")
+        let referenceProvider = ReferenceProvider(type: "A", tag: nil, scoped: nil, collectionType: nil, reference: "reference_id")
+        let moduleA = Module(
+            type: "Test",
+            providers: [],
+            danglingProviders: [],
+            referenceProviders: [referenceProvider],
+            includedModules: [],
+            subcomponents: []
+        )
+        let moduleB = Module(
+            type: "Test_2",
+            providers: [],
+            danglingProviders: [danglingProvider],
+            referenceProviders: [],
+            includedModules: [],
+            subcomponents: []
+        )
+        
+        
+        let file = FileRepresentation(
+            components: [],
+            modules: [moduleA, moduleB])
+        let moduleRep = ModuleRepresentation(
+            files: [file]
+        )
+        let interface = Linker.link(modules: [moduleRep])
+        XCTAssertEqual(interface.modules.count, 2)
+        XCTAssertEqual(interface.modules.first!.providers.count, 1)
+        XCTAssertEqual(interface.modules[1].providers.count, 0)
+    }
+    
+    func testMissingDangling() {
+        let referenceProvider = ReferenceProvider(type: "A", tag: nil, scoped: nil, collectionType: nil, reference: "reference_id")
+        let moduleA = Module(
+            type: "Test",
+            providers: [],
+            danglingProviders: [],
+            referenceProviders: [referenceProvider],
+            includedModules: [],
+            subcomponents: []
+        )
+        
+        
+        let file = FileRepresentation(
+            components: [],
+            modules: [moduleA])
+        let moduleRep = ModuleRepresentation(
+            files: [file]
+        )
+        let interface = Linker.link(modules: [moduleRep])
+        XCTAssertEqual(interface.modules.count, 1)
+        XCTAssertEqual(interface.modules.first!.providers.count, 0)
+    }
+    
+    func testOnlyDanging() {
+        let danglingProvider = DanglingProvider(type: "A", dependencies: [], reference: "reference_id")
+        let moduleA = Module(
+            type: "Test",
+            providers: [],
+            danglingProviders: [danglingProvider],
+            referenceProviders: [],
+            includedModules: [],
+            subcomponents: []
+        )
+        
+        
+        let file = FileRepresentation(
+            components: [],
+            modules: [moduleA])
+        let moduleRep = ModuleRepresentation(
+            files: [file]
+        )
+        let interface = Linker.link(modules: [moduleRep])
+        XCTAssertEqual(interface.modules.count, 1)
+        XCTAssertEqual(interface.modules.first!.providers.count, 0)
+    }
+    
+    func testDuplicateDangling() {
+        let danglingProvider = DanglingProvider(type: "A", dependencies: [], reference: "reference_id")
+        let referenceProvider = ReferenceProvider(type: "A", tag: nil, scoped: nil, collectionType: nil, reference: "reference_id")
+        let moduleA = Module(
+            type: "Test",
+            providers: [],
+            danglingProviders: [danglingProvider, danglingProvider],
+            referenceProviders: [referenceProvider],
+            includedModules: [],
+            subcomponents: []
+        )
+        
+        
+        let file = FileRepresentation(
+            components: [],
+            modules: [moduleA])
+        let moduleRep = ModuleRepresentation(
+            files: [file]
+        )
+        let interface = Linker.link(modules: [moduleRep])
+        XCTAssertEqual(interface.modules.count, 1)
+        XCTAssertEqual(interface.modules.first!.providers.count, 1)
+    }
+}

--- a/cleansec/cleansec.xcodeproj/project.pbxproj
+++ b/cleansec/cleansec.xcodeproj/project.pbxproj
@@ -58,6 +58,11 @@
 		DC8A68142464759D00D78CAF /* DataStringMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8A68132464759D00D78CAF /* DataStringMapper.swift */; };
 		DC8A68162464760100D78CAF /* ASTStringHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8A68152464760100D78CAF /* ASTStringHelpers.swift */; };
 		DC8A681824648BEB00D78CAF /* SanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8A681724648BEB00D78CAF /* SanitizerTests.swift */; };
+		DC9966EC246B5EE80015B473 /* LinkedModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9966EB246B5EE80015B473 /* LinkedModule.swift */; };
+		DC9966EE246B5F280015B473 /* LinkedComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9966ED246B5F280015B473 /* LinkedComponent.swift */; };
+		DC9966F0246B5F4D0015B473 /* LinkedInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9966EF246B5F4D0015B473 /* LinkedInterface.swift */; };
+		DC9966F2246B5F7C0015B473 /* Linker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9966F1246B5F7C0015B473 /* Linker.swift */; };
+		DC9966F4246B63350015B473 /* LinkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9966F3246B63350015B473 /* LinkerTests.swift */; };
 		DCD333472469B3AB008B053F /* CleansecFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCD3333E2469B3AB008B053F /* CleansecFramework.framework */; };
 		DCD3334C2469B3AB008B053F /* FileVisitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD3334B2469B3AB008B053F /* FileVisitorTests.swift */; };
 		DCD3334E2469B3AB008B053F /* CleansecFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = DCD333402469B3AB008B053F /* CleansecFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -198,6 +203,11 @@
 		DC8A68132464759D00D78CAF /* DataStringMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStringMapper.swift; sourceTree = "<group>"; };
 		DC8A68152464760100D78CAF /* ASTStringHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASTStringHelpers.swift; sourceTree = "<group>"; };
 		DC8A681724648BEB00D78CAF /* SanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SanitizerTests.swift; sourceTree = "<group>"; };
+		DC9966EB246B5EE80015B473 /* LinkedModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedModule.swift; sourceTree = "<group>"; };
+		DC9966ED246B5F280015B473 /* LinkedComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedComponent.swift; sourceTree = "<group>"; };
+		DC9966EF246B5F4D0015B473 /* LinkedInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedInterface.swift; sourceTree = "<group>"; };
+		DC9966F1246B5F7C0015B473 /* Linker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Linker.swift; sourceTree = "<group>"; };
+		DC9966F3246B63350015B473 /* LinkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkerTests.swift; sourceTree = "<group>"; };
 		DCD3333E2469B3AB008B053F /* CleansecFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CleansecFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCD333402469B3AB008B053F /* CleansecFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CleansecFramework.h; sourceTree = "<group>"; };
 		DCD333412469B3AB008B053F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -424,9 +434,21 @@
 			path = Parsing;
 			sourceTree = "<group>";
 		};
+		DC9966E8246B5ED40015B473 /* Linking */ = {
+			isa = PBXGroup;
+			children = (
+				DC9966EB246B5EE80015B473 /* LinkedModule.swift */,
+				DC9966ED246B5F280015B473 /* LinkedComponent.swift */,
+				DC9966EF246B5F4D0015B473 /* LinkedInterface.swift */,
+				DC9966F1246B5F7C0015B473 /* Linker.swift */,
+			);
+			path = Linking;
+			sourceTree = "<group>";
+		};
 		DCD3333F2469B3AB008B053F /* CleansecFramework */ = {
 			isa = PBXGroup;
 			children = (
+				DC9966E8246B5ED40015B473 /* Linking */,
 				DCD333552469B3B0008B053F /* Visitors */,
 				DCD333402469B3AB008B053F /* CleansecFramework.h */,
 				DCD333412469B3AB008B053F /* Info.plist */,
@@ -441,6 +463,7 @@
 				DCD3334B2469B3AB008B053F /* FileVisitorTests.swift */,
 				DCD3334D2469B3AB008B053F /* Info.plist */,
 				DC849822246B393500E704D6 /* BindingsVisitorTests.swift */,
+				DC9966F3246B63350015B473 /* LinkerTests.swift */,
 			);
 			path = CleansecFrameworkTests;
 			sourceTree = "<group>";
@@ -821,12 +844,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				DC849812246B09E500E704D6 /* CleanseTypeVisitor.swift in Sources */,
+				DC9966F0246B5F4D0015B473 /* LinkedInterface.swift in Sources */,
 				DC849821246B2FEB00E704D6 /* ComponentRootProviderVisitor.swift in Sources */,
+				DC9966EE246B5F280015B473 /* LinkedComponent.swift in Sources */,
 				DC84981B246B249D00E704D6 /* ProviderBuilders.swift in Sources */,
 				DC849808246B050F00E704D6 /* FileVisitor.swift in Sources */,
 				DCD333572469B3E5008B053F /* Models.swift in Sources */,
 				DC849816246B140500E704D6 /* ProviderVisitor.swift in Sources */,
+				DC9966EC246B5EE80015B473 /* LinkedModule.swift in Sources */,
 				DC849814246B132C00E704D6 /* BindingsVisitor.swift in Sources */,
+				DC9966F2246B5F7C0015B473 /* Linker.swift in Sources */,
 				DCD333592469B4E4008B053F /* ProviderModels.swift in Sources */,
 				DC84981F246B275500E704D6 /* ReferenceProviderVisitor.swift in Sources */,
 				DC84981D246B268700E704D6 /* DanglingProviderVisitor.swift in Sources */,
@@ -837,6 +864,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DC9966F4246B63350015B473 /* LinkerTests.swift in Sources */,
 				DC849804246A208400E704D6 /* CodeFixtures.swift in Sources */,
 				DC849823246B393500E704D6 /* BindingsVisitorTests.swift in Sources */,
 				DCD3334C2469B3AB008B053F /* FileVisitorTests.swift in Sources */,


### PR DESCRIPTION
Linker step is responsible for joining all the `ReferenceProvider` instances to their corresponding `DanglingProvider`. These references can be linked across different `ModuleRepresentation` instances (i.e. different Swift modules).