### PR TITLE
Expose visitor publicly for plugins to reuse.

### DIFF
--- a/cleansec/CleansecFramework/Visitors/CleanseTypeVisitor.swift
+++ b/cleansec/CleansecFramework/Visitors/CleanseTypeVisitor.swift
@@ -17,8 +17,10 @@ import SwiftAstParser
  any implementation that conforms to the sub-protocol.
  
  */
-struct CleanseTypeVisitor: SyntaxVisitor {
-    enum CleanseType {
+public struct CleanseTypeVisitor: SyntaxVisitor {
+    public init() {}
+    
+    public enum CleanseType {
         case none, module, component
     }
     
@@ -34,27 +36,27 @@ struct CleanseTypeVisitor: SyntaxVisitor {
     private var seenTypealiases: [TypealiasType] = []
     private var seenFunctions: [Function] = []
     
-    mutating func visitChildren(node: StructDecl) -> Bool {
+    public mutating func visitChildren(node: StructDecl) -> Bool {
         false
     }
     
-    mutating func visitChildren(node: ClassDecl) -> Bool {
+    public mutating func visitChildren(node: ClassDecl) -> Bool {
         false
     }
     
-    mutating func visit(node: Typealias) {
+    public mutating func visit(node: Typealias) {
         if let rawType = node.raw.firstCapture(#"\"(\w+)\""#), let type = TypealiasType(rawValue: rawType) {
             seenTypealiases.append(type)
         }
     }
     
-    mutating func visit(node: FuncDecl) {
+    public mutating func visit(node: FuncDecl) {
         if let rawType = node.raw.firstCapture(#"\"(.*)\""#), let type = Function(rawValue: rawType) {
             seenFunctions.append(type)
         }
     }
     
-    func finalize() -> CleanseType {
+    public func finalize() -> CleanseType {
         guard seenTypealiases.contains(.scope), seenFunctions.contains(.configure) else {
             return .none
         }

--- a/cleansec/CleansecFramework/Visitors/Provider Visitor/ComponentRootProviderVisitor.swift
+++ b/cleansec/CleansecFramework/Visitors/Provider Visitor/ComponentRootProviderVisitor.swift
@@ -12,8 +12,10 @@ import SwiftAstParser
 /**
  Responsible for extracting out the root provider instance and seed type for a given component body.
  */
-struct ComponentRootProviderVisitor: SyntaxVisitor {
-    enum RootProvider {
+public struct ComponentRootProviderVisitor: SyntaxVisitor {
+    public init() {}
+    
+    public enum RootProvider {
         case dangling(DanglingProvider)
         case reference(ReferenceProvider)
     }
@@ -21,7 +23,7 @@ struct ComponentRootProviderVisitor: SyntaxVisitor {
     private var seed = "Void"
     private var rootProvider: RootProvider?
     
-    mutating func visit(node: Typealias) {
+    public mutating func visit(node: Typealias) {
         if node.raw.contains("\"Seed\"") {
             if let type = node.type.firstCapture(#"'(\w+)'"#), type != "Void" {
                 seed = type
@@ -29,7 +31,7 @@ struct ComponentRootProviderVisitor: SyntaxVisitor {
         }
     }
     
-    mutating func visit(node: FuncDecl) {
+    public mutating func visit(node: FuncDecl) {
         if node.raw.contains("configureRoot(binder:)") {
             var bindingsVisitor = BindingsVisitor()
             bindingsVisitor.walk(node)
@@ -42,7 +44,7 @@ struct ComponentRootProviderVisitor: SyntaxVisitor {
         }
     }
     
-    func finalize() -> (String, RootProvider?) {
+    public func finalize() -> (String, RootProvider?) {
         return (seed, rootProvider)
     }
 }

--- a/cleansec/CleansecFramework/Visitors/Representations/Models.swift
+++ b/cleansec/CleansecFramework/Visitors/Representations/Models.swift
@@ -21,6 +21,11 @@ public struct ModuleRepresentation: Codable {
 public struct FileRepresentation: Codable {
     public let components: [Component]
     public let modules: [Module]
+    
+    public init(components: [Component], modules: [Module]) {
+        self.components = components
+        self.modules = modules
+    }
 }
 
 /// Cleanse `Component` representation.
@@ -34,6 +39,28 @@ public struct Component: Codable {
     public let includedModules: [String]
     public let subcomponents: [String]
     public let isRoot: Bool
+    
+    public init(
+        type: String,
+        rootType: String,
+        providers: [StandardProvider],
+        danglingProviders: [DanglingProvider],
+        referenceProviders: [ReferenceProvider],
+        seed: String,
+        includedModules: [String],
+        subcomponents: [String],
+        isRoot: Bool
+    ) {
+        self.type = type
+        self.rootType = rootType
+        self.providers = providers
+        self.danglingProviders = danglingProviders
+        self.referenceProviders = referenceProviders
+        self.seed = seed
+        self.includedModules = includedModules
+        self.subcomponents = subcomponents
+        self.isRoot = isRoot
+    }
 }
 
 /// Cleanse `Module` representation.
@@ -44,4 +71,20 @@ public struct Module: Codable {
     public let referenceProviders: [ReferenceProvider]
     public let includedModules: [String]
     public let subcomponents: [String]
+    
+    public init(
+        type: String,
+        providers: [StandardProvider],
+        danglingProviders: [DanglingProvider],
+        referenceProviders: [ReferenceProvider],
+        includedModules: [String],
+        subcomponents: [String]
+    ) {
+        self.type = type
+        self.providers = providers
+        self.danglingProviders = danglingProviders
+        self.referenceProviders = referenceProviders
+        self.includedModules = includedModules
+        self.subcomponents = subcomponents
+    }
 }

--- a/cleansec/CleansecFramework/Visitors/Representations/ProviderModels.swift
+++ b/cleansec/CleansecFramework/Visitors/Representations/ProviderModels.swift
@@ -7,6 +7,14 @@ public struct StandardProvider: Equatable, Codable {
     public let tag: String?
     public let scoped: String?
     public let collectionType: String?
+    
+    public init(type: String, dependencies: [String], tag: String?, scoped: String?, collectionType: String?) {
+        self.type = type
+        self.dependencies = dependencies
+        self.tag = tag
+        self.scoped = scoped
+        self.collectionType = collectionType
+    }
 }
 
 /// Partial provider presentation with known dependencies, but isn't bound into object graph yet.

--- a/cleansec/script/swiftc-ast.rb
+++ b/cleansec/script/swiftc-ast.rb
@@ -44,7 +44,7 @@ def main
 	pipe_to_file_command = ['2>&1']
 	if output_file = input.grep(/DAST_FILE/).first
 		outpath_file_path = output_file.split('=')[1]
-		FileUtils.mkdir_p(Pathname.new(outpath_file_path).basename)
+		FileUtils.mkdir_p(Pathname.new(outpath_file_path).dirname)
 		pipe_to_file_command = ['&>'] + [outpath_file_path]
 	end
 


### PR DESCRIPTION
* Also fixes critical `swiftc-ast` script bug where `mkdir -p` was being applied to the basename instead of dirname.