### PR TITLE
Plumb DebugData through pipeline.

### DIFF
--- a/cleansec/CleansecFramework/Linking/Linker.swift
+++ b/cleansec/CleansecFramework/Linking/Linker.swift
@@ -81,7 +81,8 @@ public struct Linker {
                 dependencies: linked.dependencies,
                 tag: referenceProvider.tag,
                 scoped: referenceProvider.scoped,
-                collectionType: referenceProvider.collectionType
+                collectionType: referenceProvider.collectionType,
+                debugData: referenceProvider.debugData
             )
         }
     }

--- a/cleansec/CleansecFramework/Resolver/CanonicalProvider.swift
+++ b/cleansec/CleansecFramework/Resolver/CanonicalProvider.swift
@@ -15,6 +15,7 @@ public struct CanonicalProvider: Equatable {
     public let type: String
     public let dependencies: [String]
     public let isCollectionProvider: Bool
+    public let debugData: DebugData
 }
 
 extension CanonicalProvider: CustomStringConvertible {
@@ -28,7 +29,8 @@ extension CanonicalProvider {
         return CanonicalProvider(
             type: "Provider<\(type)>",
             dependencies: dependencies,
-            isCollectionProvider: isCollectionProvider
+            isCollectionProvider: isCollectionProvider,
+            debugData: debugData
         )
     }
     
@@ -42,7 +44,8 @@ extension LinkedComponent {
         return CanonicalProvider(
             type: seed,
             dependencies: [],
-            isCollectionProvider: false
+            isCollectionProvider: false,
+            debugData: .empty
         )
     }
     
@@ -50,7 +53,8 @@ extension LinkedComponent {
         return CanonicalProvider(
             type: "ComponentFactory<\(type)>",
             dependencies: [],
-            isCollectionProvider: false
+            isCollectionProvider: false,
+            debugData: .empty
         )
     }
 }
@@ -61,20 +65,23 @@ extension StandardProvider {
             return CanonicalProvider(
                 type: "TaggedProvider<\(tag)>",
                 dependencies: dependencies,
-                isCollectionProvider: collectionType != nil
+                isCollectionProvider: collectionType != nil,
+                debugData: debugData
             )
         }
         if let collection = collectionType {
             return CanonicalProvider(
                 type: collection,
                 dependencies: dependencies,
-                isCollectionProvider: true
+                isCollectionProvider: true,
+                debugData: debugData
             )
         }
         return CanonicalProvider(
             type: type,
             dependencies: dependencies,
-            isCollectionProvider: false
+            isCollectionProvider: false,
+            debugData: debugData
         )
     }
 }

--- a/cleansec/CleansecFramework/Resolver/ResolutionError.swift
+++ b/cleansec/CleansecFramework/Resolver/ResolutionError.swift
@@ -12,8 +12,8 @@ public struct ResolutionError: Equatable, Error {
     public enum Error: Equatable {
         case missingModule(String)
         case missingSubcomponent(String)
-        case duplicateProvider(String)
-        case missingProvider(String)
+        case duplicateProvider(CanonicalProvider)
+        case missingProvider(dependency: String, dependedUpon: CanonicalProvider?)
     }
     
     let type: Error
@@ -22,14 +22,19 @@ public struct ResolutionError: Equatable, Error {
 extension ResolutionError: CustomStringConvertible {
     public var description: String {
         switch type {
-        case .missingProvider(let provider):
-            return "Missing Provider: \(provider)."
+        case .missingProvider(let provider, let parent):
+            var base = "Missing Provider: \(provider).\n"
+            if let p = parent {
+                let indent = String(repeatElement(" ", count: 2))
+                base += "\(indent)Depended upon by: \(p.type):\(p.debugData.location ?? "")\n\(indent)\(p.type) --> \(provider)\n"
+            }
+            return base
         case .missingSubcomponent(let subcomponent):
             return "Missing Installed Compoment: \(subcomponent)."
         case .missingModule(let module):
             return "Missing included Module: \(module)."
         case .duplicateProvider(let provider):
-            return "Duplicate binding for: \(provider)"
+            return "Duplicate binding for \(provider.type): \(provider.debugData.location ?? "")"
         }
     }
 }

--- a/cleansec/CleansecFramework/Visitors/Provider Visitor/ProviderBuilders.swift
+++ b/cleansec/CleansecFramework/Visitors/Provider Visitor/ProviderBuilders.swift
@@ -21,6 +21,7 @@ struct ReferenceProviderBuilder {
     let collectionType: String?
     let dependencies: [String]?
     let reference: String?
+    let debugData: DebugData
     
     // A potential reference provider can turn into a standard provider
     // by passing a closure to the configured function.
@@ -32,7 +33,9 @@ struct ReferenceProviderBuilder {
                 dependencies: dependencies,
                 tag: tag,
                 scoped: scope,
-                collectionType: collectionType))
+                collectionType: collectionType,
+                debugData: debugData
+            ))
         }
         if let reference = reference {
             return .reference(ReferenceProvider(
@@ -40,7 +43,9 @@ struct ReferenceProviderBuilder {
                 tag: tag,
                 scoped: scope,
                 collectionType: collectionType,
-                reference: reference))
+                reference: reference,
+                debugData: debugData
+            ))
         }
         
         fatalError("Cannot reach via precondition.")
@@ -53,7 +58,9 @@ struct ReferenceProviderBuilder {
             scope: scope,
             collectionType: collectionType,
             dependencies: nil,
-            reference: reference)
+            reference: reference,
+            debugData: debugData
+        )
     }
     
     func setDependencies(dependencies: [String]) -> ReferenceProviderBuilder {
@@ -63,7 +70,9 @@ struct ReferenceProviderBuilder {
             scope: scope,
             collectionType: collectionType,
             dependencies: dependencies,
-            reference: nil)
+            reference: nil,
+            debugData: debugData
+        )
     }
 }
 
@@ -73,9 +82,10 @@ struct DanglingProviderBuilder {
     let type: String
     let dependencies: [String]
     let reference: String?
+    let debugData: DebugData
     
     func setReference(_ reference: String) -> DanglingProviderBuilder {
-        return DanglingProviderBuilder(type: type, dependencies: dependencies, reference: reference)
+        return DanglingProviderBuilder(type: type, dependencies: dependencies, reference: reference, debugData: debugData)
     }
     
     func build() -> DanglingProvider {
@@ -83,7 +93,8 @@ struct DanglingProviderBuilder {
         return DanglingProvider(
             type: type,
             dependencies: dependencies,
-            reference: reference!
+            reference: reference!,
+            debugData: debugData
         )
     }
 }

--- a/cleansec/CleansecFramework/Visitors/Representations/DebugData.swift
+++ b/cleansec/CleansecFramework/Visitors/Representations/DebugData.swift
@@ -1,0 +1,19 @@
+//
+//  DebugData.swift
+//  CleansecFramework
+//
+//  Created by Sebastian Edward Shanus on 5/26/20.
+//  Copyright © 2020 Square. All rights reserved.
+//
+
+import Foundation
+
+public struct DebugData: Equatable, Codable {
+    public let location: String?
+    
+    public static var empty = DebugData(location: nil)
+    
+    public static func location(_ loc: String) -> DebugData {
+        DebugData(location: loc)
+    }
+}

--- a/cleansec/CleansecFramework/Visitors/Representations/ProviderModels.swift
+++ b/cleansec/CleansecFramework/Visitors/Representations/ProviderModels.swift
@@ -7,13 +7,15 @@ public struct StandardProvider: Equatable, Codable {
     public let tag: String?
     public let scoped: String?
     public let collectionType: String?
+    public let debugData: DebugData
     
-    public init(type: String, dependencies: [String], tag: String?, scoped: String?, collectionType: String?) {
+    public init(type: String, dependencies: [String], tag: String?, scoped: String?, collectionType: String?, debugData: DebugData = .empty) {
         self.type = type
         self.dependencies = dependencies
         self.tag = tag
         self.scoped = scoped
         self.collectionType = collectionType
+        self.debugData = debugData
     }
 }
 
@@ -23,6 +25,14 @@ public struct DanglingProvider: Equatable, Codable {
     public let type: String
     public let dependencies: [String]
     public let reference: String
+    public let debugData: DebugData
+    
+    public init(type: String, dependencies: [String], reference: String, debugData: DebugData = .empty) {
+        self.type = type
+        self.dependencies = dependencies
+        self.reference = reference
+        self.debugData = debugData
+    }
 }
 
 /// Provider bound into object graph, but referenced a dangling provider, thus its dependencies are unknown.
@@ -32,4 +42,14 @@ public struct ReferenceProvider: Equatable, Codable {
     public let scoped: String?
     public let collectionType: String?
     public let reference: String
+    public let debugData: DebugData
+    
+    public init(type: String, tag: String?, scoped: String?, collectionType: String?, reference: String, debugData: DebugData = .empty) {
+        self.type = type
+        self.tag = tag
+        self.scoped = scoped
+        self.collectionType = collectionType
+        self.reference = reference
+        self.debugData = debugData
+    }
 }

--- a/cleansec/CleansecFrameworkTests/BindingsVisitorTests.swift
+++ b/cleansec/CleansecFrameworkTests/BindingsVisitorTests.swift
@@ -108,7 +108,11 @@ class BindingsVisitorTests: XCTestCase {
         visitor.walk(node)
         let result = visitor.finalize()
         XCTAssertEqual(result.standardProviders.count, 1)
-        XCTAssertEqual(result.standardProviders.first!, StandardProvider(type: "Factory<AssistedSeed>", dependencies: ["String"], tag: nil, scoped: nil, collectionType: nil))
+        XCTAssertEqual(result.standardProviders.first!.type, "Factory<AssistedSeed>")
+        XCTAssertEqual(result.standardProviders.first!.dependencies, ["String"])
+        XCTAssertNil(result.standardProviders.first!.tag)
+        XCTAssertNil(result.standardProviders.first!.scoped)
+        XCTAssertNil(result.standardProviders.first!.collectionType)
     }
 
     func testTaggedProviderDependency() {
@@ -162,5 +166,24 @@ class BindingsVisitorTests: XCTestCase {
         visitor.walk(node)
         let result = visitor.finalize()
         XCTAssertEqual(result.standardProviders.first!.dependencies.count, 10)
+    }
+    
+    func testDebugData() {
+         let node = SyntaxParser.parse(text: Fixtures.ModuleWithDependencies).first!
+        visitor.walk(node)
+        let result = visitor.finalize()
+        XCTAssertNotNil(result.standardProviders.first!.debugData.location)
+        XCTAssertTrue(result.standardProviders.first!.debugData.location!.hasSuffix("ModuleWithDependencies.swift:16:10"))
+    }
+    
+    func testDebugDataReferenceAndDangling() {
+        let node = SyntaxParser.parse(text: Fixtures.DanglingAndReference).first!
+        visitor.walk(node)
+        let result = visitor.finalize()
+        XCTAssertNotNil(result.referenceProviders.first!.debugData.location)
+        XCTAssertTrue(result.referenceProviders.first!.debugData.location!.hasSuffix("DanglingAndReference.swift:20:36"))
+        XCTAssertNotNil(result.danglingProviders.first!.debugData.location)
+        XCTAssertTrue(result.danglingProviders.first!.debugData.location!.hasSuffix("DanglingAndReference.swift:14:21"))
+
     }
 }

--- a/cleansec/CleansecFrameworkTests/ResolverTests.swift
+++ b/cleansec/CleansecFrameworkTests/ResolverTests.swift
@@ -88,7 +88,7 @@ class ResolverTests: XCTestCase {
         let resolvedComponents = Resolver.resolve(interface: interface)
         XCTAssertEqual(resolvedComponents.count, 1)
         XCTAssertEqual(resolvedComponents.first!.diagnostics.count, 1)
-        XCTAssertEqual(resolvedComponents.first!.diagnostics.first!, ResolutionError(type: .duplicateProvider("[A]")))
+        XCTAssertEqual(resolvedComponents.first!.diagnostics.first!, ResolutionError(type: .duplicateProvider(collectionProviders[1].mapToCanonical())))
     }
     
     func testDuplicateBinding() {
@@ -111,7 +111,7 @@ class ResolverTests: XCTestCase {
         let resolvedComponents = Resolver.resolve(interface: interface)
         XCTAssertEqual(resolvedComponents.count, 1)
         XCTAssertEqual(resolvedComponents.first!.diagnostics.count, 1)
-        XCTAssertEqual(resolvedComponents.first!.diagnostics.first!, ResolutionError(type: .duplicateProvider("A")))
+        XCTAssertEqual(resolvedComponents.first!.diagnostics.first!, ResolutionError(type: .duplicateProvider(providers.first!.mapToCanonical())))
     }
     
     func testDuplicateModuleIncludesIsOkay() {

--- a/cleansec/cleansec.xcodeproj/project.pbxproj
+++ b/cleansec/cleansec.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		DCD333572469B3E5008B053F /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD333562469B3E5008B053F /* Models.swift */; };
 		DCD333592469B4E4008B053F /* ProviderModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD333582469B4E4008B053F /* ProviderModels.swift */; };
 		DCF196512472F3580057BDC5 /* PluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF196502472F3580057BDC5 /* PluginTests.swift */; };
+		DCF9EAC6247D716700FDE003 /* DebugData.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF9EAC5247D716700FDE003 /* DebugData.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -249,6 +250,7 @@
 		DCD333562469B3E5008B053F /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Models.swift; path = CleansecFramework/Visitors/Representations/Models.swift; sourceTree = SOURCE_ROOT; };
 		DCD333582469B4E4008B053F /* ProviderModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ProviderModels.swift; path = CleansecFramework/Visitors/Representations/ProviderModels.swift; sourceTree = SOURCE_ROOT; };
 		DCF196502472F3580057BDC5 /* PluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginTests.swift; sourceTree = "<group>"; };
+		DCF9EAC5247D716700FDE003 /* DebugData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugData.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -537,6 +539,7 @@
 			children = (
 				DCD333562469B3E5008B053F /* Models.swift */,
 				DCD333582469B4E4008B053F /* ProviderModels.swift */,
+				DCF9EAC5247D716700FDE003 /* DebugData.swift */,
 			);
 			path = Representations;
 			sourceTree = "<group>";
@@ -920,6 +923,7 @@
 				DC849814246B132C00E704D6 /* BindingsVisitor.swift in Sources */,
 				DC9966F2246B5F7C0015B473 /* Linker.swift in Sources */,
 				DC9966FE246C60EE0015B473 /* CanonicalProvider.swift in Sources */,
+				DCF9EAC6247D716700FDE003 /* DebugData.swift in Sources */,
 				DCD333592469B4E4008B053F /* ProviderModels.swift in Sources */,
 				DC84981F246B275500E704D6 /* ReferenceProviderVisitor.swift in Sources */,
 				DC9966FC246C58560015B473 /* ResolutionError.swift in Sources */,


### PR DESCRIPTION
* Creates new `DebugData` struct to provide additional metadata on core primitives.
* Makes the `ResolutionError` types error-rich by providing the debug data in the exception.