### PR TITLE
Grant public access to CleansecFramework Visitors.

### DIFF
--- a/cleansec/CleansecFramework/Visitors/Provider Visitor/ProviderBuilders.swift
+++ b/cleansec/CleansecFramework/Visitors/Provider Visitor/ProviderBuilders.swift
@@ -10,8 +10,8 @@ import Foundation
 
 /// Represents a partial reference provider value. Exposes public method needed to fill in the missing
 /// properties and then build the resulting `ReferenceProvider`.
-struct ReferenceProviderBuilder {
-    enum ResultingProvider {
+public struct ReferenceProviderBuilder {
+    public enum ResultingProvider {
         case reference(ReferenceProvider)
         case standard(StandardProvider)
     }
@@ -25,7 +25,7 @@ struct ReferenceProviderBuilder {
     
     // A potential reference provider can turn into a standard provider
     // by passing a closure to the configured function.
-    func build() -> ResultingProvider {
+    public func build() -> ResultingProvider {
         precondition(dependencies != nil || reference != nil, "Must supply a dependencies list or reference before building.")
         if let dependencies = dependencies {
             return .standard(StandardProvider(
@@ -51,7 +51,7 @@ struct ReferenceProviderBuilder {
         fatalError("Cannot reach via precondition.")
     }
     
-    func setReference(reference: String) -> ReferenceProviderBuilder {
+    public func setReference(reference: String) -> ReferenceProviderBuilder {
         return ReferenceProviderBuilder(
             type: type,
             tag: tag,
@@ -63,7 +63,7 @@ struct ReferenceProviderBuilder {
         )
     }
     
-    func setDependencies(dependencies: [String]) -> ReferenceProviderBuilder {
+    public func setDependencies(dependencies: [String]) -> ReferenceProviderBuilder {
         return ReferenceProviderBuilder(
             type: type,
             tag: tag,
@@ -78,17 +78,17 @@ struct ReferenceProviderBuilder {
 
 /// Represents a partial dangling provider value. Exposes public method needed to fill in the missing
 /// properties and then build the resulting `DanglingProvider`.
-struct DanglingProviderBuilder {
+public struct DanglingProviderBuilder {
     let type: String
     let dependencies: [String]
     let reference: String?
     let debugData: DebugData
     
-    func setReference(_ reference: String) -> DanglingProviderBuilder {
+    public func setReference(_ reference: String) -> DanglingProviderBuilder {
         return DanglingProviderBuilder(type: type, dependencies: dependencies, reference: reference, debugData: debugData)
     }
     
-    func build() -> DanglingProvider {
+    public func build() -> DanglingProvider {
         precondition(reference != nil, "Must set a reference on the builder before building.")
         return DanglingProvider(
             type: type,

--- a/cleansec/CleansecFramework/Visitors/Provider Visitor/ProviderVisitor.swift
+++ b/cleansec/CleansecFramework/Visitors/Provider Visitor/ProviderVisitor.swift
@@ -9,7 +9,7 @@
 import Foundation
 import SwiftAstParser
 
-enum ProviderResult {
+public enum ProviderResult {
     case provider(StandardProvider)
     case danglingProviderBuilder(DanglingProviderBuilder)
     case referenceBuilder(ReferenceProviderBuilder)
@@ -18,19 +18,19 @@ enum ProviderResult {
 /**
  Parses an individual binding to discern its provider type, dependencies, and any decorated types (i.e Tagged, Scoped, Factory).
  */
-struct ProviderVisitor: SyntaxVisitor {
+public struct ProviderVisitor: SyntaxVisitor {
     private var binding: BindingType = .unknown
     private var dependencies: [String] = []
     private var bindingTypeBuilder = BaseBindingTypeBuilder.instance
     
-    let type: String
+    public let type: String
     
-    init(type: String) {
+    public init(type: String) {
         self.type = type
     }
     
     // We just want to visit the first declrefExpr to discern the API used.
-    mutating func visit(node: DeclrefExpr) {
+    public mutating func visit(node: DeclrefExpr) {
         guard binding == .unknown else {
             return
         }
@@ -57,7 +57,7 @@ struct ProviderVisitor: SyntaxVisitor {
         }
     }
     
-    mutating func visit(node: CallExpr) {
+    public mutating func visit(node: CallExpr) {
         if node.type.matches("BindingReceipt<.*>") {
             if let loc = node.raw.firstCapture(#"location=(.*)\srange"#) {
                 bindingTypeBuilder = bindingTypeBuilder.setDebugData(.location(loc))
@@ -91,7 +91,7 @@ struct ProviderVisitor: SyntaxVisitor {
         }
     }
     
-    func finalize() -> ProviderResult? {
+    public func finalize() -> ProviderResult? {
         bindingTypeBuilder.build(bindingType: binding, type: type, dependencies: dependencies)
     }
 }


### PR DESCRIPTION
These can be reused for plugins when attempting to parse structures similar to the default bindings.