### PR TITLE
Replace print with os_log.

### DIFF
--- a/cleansec/CleansecFramework/Cleansec.swift
+++ b/cleansec/CleansecFramework/Cleansec.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import SwiftAstParser
+import os.log
 
 /**
  Primary public inteface for pipeline steps.
@@ -40,14 +41,14 @@ public struct Cleansec {
         do {
             try process.run()
         } catch {
-            print("Plugin process failed: \(error)")
+            os_log("Plugin process failed: %@", type: .debug, String(describing: error))
             return nil
         }
         let data = output.fileHandleForReading.readDataToEndOfFile()
         do {
             return try JSONDecoder().decode(ModuleRepresentation.self, from: data)
         } catch {
-            print("Failed to parse plugin output to `ModuleRepresentation`. Make sure you using JSONDecoder over a `ModuleRepresentation` instance.")
+            os_log("Failed to parse plugin output to `ModuleRepresentation`. Make sure you using JSONDecoder over a `ModuleRepresentation` instance.", type: .info)
             return nil
         }
     }

--- a/cleansec/CleansecFramework/Linking/Linker.swift
+++ b/cleansec/CleansecFramework/Linking/Linker.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import os.log
 
 /**
  The Linker is repsonsible for linking `ReferenceProvider` instances to their respective `DanglingProvider`.
@@ -28,7 +29,7 @@ public struct Linker {
         let danglingProviders = components.flatMap { $0.danglingProviders } + modules.flatMap { $0.danglingProviders }
         let danglingProvidersByReference = danglingProviders.reduce(into: [String:DanglingProvider]()) { (dict, provider) in
             if let _ = dict[provider.reference] {
-                print("Warning: Duplicate dangling provider reference: \(provider.reference)")
+                os_log("Warning: Duplicate dangling provider reference: %@", type: .debug, provider.reference)
             }
             dict[provider.reference] = provider
         }
@@ -73,7 +74,7 @@ public struct Linker {
     private static func link(referenceProviders: [ReferenceProvider], danglingProvidersByReference: [String:DanglingProvider]) -> [StandardProvider] {
         return referenceProviders.compactMap { referenceProvider -> StandardProvider? in
             guard let linked = danglingProvidersByReference[referenceProvider.reference] else {
-                print("Warning: Failed to find pointee for reference provider: \(referenceProvider)")
+                os_log("Warning: Failed to find pointee for reference provider: %@", type: .debug, referenceProvider.type)
                 return nil
             }
             return StandardProvider(

--- a/cleansec/CleansecFramework/Resolver/ResolutionError.swift
+++ b/cleansec/CleansecFramework/Resolver/ResolutionError.swift
@@ -27,7 +27,7 @@ extension ResolutionError: CustomStringConvertible {
             var errorDescription = errorPrefix(debug: parent?.debugData)
             errorDescription += "Missing Provider: '\(provider)'\n"
             if let p = parent {
-                errorDescription += "Depended upon by: '\(p.type)'\n'\(p.type)' --> '\(provider)'\n"
+                errorDescription += "Depended upon by: '\(p.type)'"
             }
             
             return errorDescription

--- a/cleansec/CleansecFramework/Visitors/FileVisitor.swift
+++ b/cleansec/CleansecFramework/Visitors/FileVisitor.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import SwiftAstParser
+import os.log
 
 /**
  Primary parsing object that will walk a source file node and extract any cleanse objects.
@@ -49,7 +50,7 @@ struct FileVisitor: SyntaxVisitor {
             break
         case .module:
             guard let moduleName = inheritableNode.raw.firstCapture(#"interface type='(.*)\.Type'"#) else {
-                print("Found module. Unable to parse interface type: \(inheritableNode.raw)")
+                os_log("Found module. Unable to parse interface type: %@", type: .debug, inheritableNode.raw)
                 return
             }
             var bindingsVisitor = BindingsVisitor()
@@ -59,7 +60,7 @@ struct FileVisitor: SyntaxVisitor {
             )
         case .component:
             guard let componentName = inheritableNode.raw.firstCapture(#"interface type='(.*)\.Type'"#) else {
-                print("Found component. Unable to parse interface type: \(inheritableNode.raw)")
+                os_log("Found component. Unable to parse interface type: %@", type: .debug, inheritableNode.raw)
                 return
             }
             let isRoot = inheritableNode.inherits?.matches("^(Cleanse.)?RootComponent") ?? false
@@ -69,7 +70,7 @@ struct FileVisitor: SyntaxVisitor {
             componentRootVisitor.walk(inheritableNode)
             let (seed, rootProvider) = componentRootVisitor.finalize()
             guard let root = rootProvider else {
-                print("Unable to discern root provider for component \(componentName). Not creating component for: \(inheritableNode.raw)")
+                os_log("Unable to discern root provider for component %@. Not creating component for: %@", type: .debug, componentName, inheritableNode.raw)
                 return
             }
             switch root {

--- a/cleansec/CleansecFramework/Visitors/Provider Visitor/ProviderVisitor.swift
+++ b/cleansec/CleansecFramework/Visitors/Provider Visitor/ProviderVisitor.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import SwiftAstParser
+import os.log
 
 public enum ProviderResult {
     case provider(StandardProvider)
@@ -80,13 +81,13 @@ public struct ProviderVisitor: SyntaxVisitor {
             if let tag = node.type.allCaptures(#"(\w+(?:\.\w+)*)(?=>)"#).last {
                 bindingTypeBuilder = bindingTypeBuilder.setTaggedBinding(tag: tag)
             } else {
-                print("Found tagged provider, but failed to parse Tag")
+                os_log("Found tagged provider, but failed to parse Tag", type: .debug)
             }
         case .scopedProvider:
             if let scope = node.type.allCaptures(#"(\w+)(?=>)"#).last {
                 bindingTypeBuilder = bindingTypeBuilder.setScopedBinding(scope: scope)
             } else {
-                print("Found scoped provider, but failed to parse scope")
+                os_log("Found scoped provider, but failed to parse scope", type: .debug)
             }
         }
     }

--- a/cleansec/SwiftAstParser/Regex.swift
+++ b/cleansec/SwiftAstParser/Regex.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os.log
 
 public struct RegexCapture {
     public let groups: [String]
@@ -14,7 +15,7 @@ public extension String {
             }
             return true
         } catch {
-            print("Failed to formulate regex: \(error)")
+            os_log("Failed to formulate regex: %@", type: .debug, String(describing: error))
             return false
         }
     }
@@ -35,7 +36,7 @@ public extension String {
                 return RegexCapture(groups: captures)
             }
         } catch {
-            print("Failed to formulate regex: \(error)")
+            os_log("Failed to formulate regex: %@", type: .debug, String(describing: error))
             return []
         }
     }


### PR DESCRIPTION
The existing print statements are replaced with `debug` level logging via `os_log`. This will emit useful debugging info, but not pollute the usage of `cleansec` in production.