### PR TITLE
[cleansec] Resolve Tagged Providers bug fix.

### DIFF
--- a/cleansec/CleansecFramework/Resolver/CanonicalProvider.swift
+++ b/cleansec/CleansecFramework/Resolver/CanonicalProvider.swift
@@ -53,7 +53,7 @@ extension CanonicalProvider {
     }
     
     var isLazyProvider: Bool {
-        return type.matches("Provider<.*>")
+        return type.matches("^Provider<.*>")
     }
     
     var isImplicitProvider: Bool {
@@ -61,7 +61,7 @@ extension CanonicalProvider {
     }
     
     var isWeakProvider: Bool {
-        return type.matches("WeakProvider<.*>")
+        return type.matches("^WeakProvider<.*>")
     }
 }
 

--- a/cleansec/CleansecFrameworkTests/ResolverTests.swift
+++ b/cleansec/CleansecFrameworkTests/ResolverTests.swift
@@ -401,4 +401,22 @@ class ResolverTests: XCTestCase {
         XCTAssertEqual(resolved.first!.diagnostics.first!, ResolutionError(type: .cyclicalDependency(chain: ["DepB", "DepC", "DepB"])))
         XCTAssertEqual(resolved.first!.diagnostics[1], ResolutionError(type: .cyclicalDependency(chain: ["DepD", "DepE", "DepD"])))
     }
+    
+    func testResolvesTaggedProviders() {
+        let rootA = StandardProvider(type: "TaggedProvider<A>", dependencies: ["DepA"], tag: nil, scoped: nil, collectionType: nil)
+        let component = LinkedComponent(
+            type: "Root",
+            rootType: "TaggedProvider<A>",
+            providers: [rootA],
+            seed: "Void",
+            includedModules: [],
+            subcomponents: [],
+            isRoot: true
+        )
+        let interface = LinkedInterface(components: [component], modules: [])
+        let resolved = Resolver.resolve(interface: interface)
+        XCTAssertEqual(resolved.count, 1)
+        XCTAssertEqual(resolved.first!.diagnostics.count, 1)
+        XCTAssertEqual(resolved.first!.diagnostics.first!, ResolutionError(type: .missingProvider(dependency: "DepA", dependedUpon: rootA.mapToCanonical())))
+    }
 }


### PR DESCRIPTION
* Tagged providers were being filtered from resolution due to bad regex patterns. This is a temporary patch, reworking how we map `CanonicalProviders` into sibling implicit, lazy, and Weak Pproviders is a better long term fix to this issue.