### PR TITLE
Refactoring improvements for Resolver.

### DIFF
--- a/cleansec/CleansecFramework/Resolver/ResolutionError.swift
+++ b/cleansec/CleansecFramework/Resolver/ResolutionError.swift
@@ -13,8 +13,8 @@ public struct ResolutionError: Equatable, Error {
         case missingModule(String)
         case missingSubcomponent(String)
         case duplicateProvider([CanonicalProvider])
-        case missingProvider(dependency: String, dependedUpon: CanonicalProvider?)
-        case cyclicalDependency(chain: [String])
+        case missingProvider(dependency: TypeKey, dependedUpon: CanonicalProvider?)
+        case cyclicalDependency(chain: [TypeKey])
     }
     
     let type: Error
@@ -25,7 +25,7 @@ extension ResolutionError: CustomStringConvertible {
         switch type {
         case .missingProvider(let provider, let parent):
             var errorDescription = errorPrefix(debug: parent?.debugData)
-            errorDescription += "Missing Provider: '\(provider)'\n"
+            errorDescription += "Missing Provider: '\(provider.primaryType)'\n"
             if let p = parent {
                 errorDescription += "Depended upon by: '\(p.type)'"
             }
@@ -48,7 +48,7 @@ extension ResolutionError: CustomStringConvertible {
             
             return errorDescription
         case .cyclicalDependency(let chain):
-            let chainDescription = chain.joined(separator: " --> ")
+            let chainDescription = chain.map { $0.primaryType }.joined(separator: " --> ")
             return "error: Cycle in dependencies found: \(chainDescription)"
         }
     }

--- a/cleansec/CleansecFramework/Resolver/ResolvedComponent.swift
+++ b/cleansec/CleansecFramework/Resolver/ResolvedComponent.swift
@@ -12,10 +12,10 @@ public final class ResolvedComponent {
     public let type: String
     public weak var parent: ResolvedComponent?
     public var children: [ResolvedComponent]
-    public let providersByType: [String:[CanonicalProvider]]
+    public let providersByType: [TypeKey:[CanonicalProvider]]
     public let diagnostics: [ResolutionError]
     
-    public init(type: String, providersByType: [String:[CanonicalProvider]], children: [ResolvedComponent], parent: ResolvedComponent? = nil, diagnostics: [ResolutionError] = []) {
+    public init(type: String, providersByType: [TypeKey:[CanonicalProvider]], children: [ResolvedComponent], parent: ResolvedComponent? = nil, diagnostics: [ResolutionError] = []) {
         self.type = type
         self.providersByType = providersByType
         self.children = children

--- a/cleansec/CleansecFramework/Resolver/TypeKey.swift
+++ b/cleansec/CleansecFramework/Resolver/TypeKey.swift
@@ -1,0 +1,72 @@
+//
+//  TypeKey.swift
+//  CleansecFramework
+//
+//  Created by Sebastian Edward Shanus on 7/31/20.
+//  Copyright © 2020 Square. All rights reserved.
+//
+
+import Foundation
+import SwiftAstParser
+
+/// Normalized type representation.
+/// A single type can be represented in a few different ways: `() -> Type`, `WeakProvider<Type>`, `Provider<Type>`, or just `Type`.
+/// This normalizes the type into the canonical `Provider<Type>` that can be used for key lookup and comparisons.
+public struct TypeKey: Hashable {
+    private let rawType: String
+    private let canonicalType: String
+    
+    public init(type: String) {
+        self.rawType = type
+        if type.isCanonicalProvider {
+            self.canonicalType = type
+        } else if type.isWeakProvider, let innerType = type.firstCapture(#"^WeakProvider<(.*)>"#) {
+            self.canonicalType = "Provider<\(innerType)>"
+        } else if type.isImplicitProvider, let innerType = type.firstCapture(#"^\(\)\s->\s(.*)"#) {
+            self.canonicalType = "Provider<\(innerType)>"
+        } else {
+            self.canonicalType = "Provider<\(type)>"
+        }
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(canonicalType)
+    }
+    
+    public static func ==(lhs: Self, rhs: Self) -> Bool {
+         return lhs.canonicalType == rhs.canonicalType
+    }
+}
+
+extension TypeKey {
+    var isWeakProvider: Bool {
+        rawType.isWeakProvider
+    }
+    
+    var primaryType: String {
+        guard let inner = canonicalType.firstCapture(#"Provider<(.*)>"#) else {
+            return rawType
+        }
+        return inner
+    }
+}
+
+extension TypeKey: CustomStringConvertible {
+    public var description: String {
+        canonicalType
+    }
+}
+
+fileprivate extension String {
+    var isCanonicalProvider: Bool {
+        matches("^Provider<.*>")
+    }
+    
+    var isImplicitProvider: Bool {
+        matches(#"^\(\)\s->\s.*"#)
+    }
+    
+    var isWeakProvider: Bool {
+        matches("^WeakProvider<.*>")
+    }
+}

--- a/cleansec/CleansecFrameworkTests/ResolverTests.swift
+++ b/cleansec/CleansecFrameworkTests/ResolverTests.swift
@@ -29,12 +29,8 @@ class ResolverTests: XCTestCase {
         let interface = LinkedInterface(components: [subcomponent, component], modules: [module])
         let resolvedComponents = Resolver.resolve(interface: interface)
         XCTAssertEqual(resolvedComponents.count, 1)
-        let subcomponentFactory = resolvedComponents.first?.providersByType.keys.first { $0 == "ComponentFactory<Subcomponent>" }
-        let weakProvider = resolvedComponents.first?.providersByType.keys.first { $0 == "WeakProvider<MyClass>" }
-        let lazyProvider = resolvedComponents.first?.providersByType.keys.first { $0 == "Provider<MyClass>" }
+        let subcomponentFactory = resolvedComponents.first?.providersByType.keys.first { $0 == TypeKey(type: "ComponentFactory<Subcomponent>") }
         XCTAssertNotNil(subcomponentFactory)
-        XCTAssertNotNil(weakProvider)
-        XCTAssertNotNil(lazyProvider)
     }
     
     func testResolvesSimpleRoot() {
@@ -53,7 +49,7 @@ class ResolverTests: XCTestCase {
         let resolvedComponents = Resolver.resolve(interface: interface)
         XCTAssertEqual(resolvedComponents.count, 1)
         // Providers for Seed
-        XCTAssertEqual(resolvedComponents.first!.providersByType.count, 4)
+        XCTAssertEqual(resolvedComponents.first!.providersByType.count, 1)
     }
     
     func testCollectionBindingDuplicates() {
@@ -79,8 +75,8 @@ class ResolverTests: XCTestCase {
         let resolvedComponents = Resolver.resolve(interface: interface)
         XCTAssertEqual(resolvedComponents.count, 1)
         XCTAssertEqual(resolvedComponents.first!.diagnostics.count, 0)
-        XCTAssertEqual(resolvedComponents.first!.providersByType["[A]"]!.count, 2)
-        XCTAssertEqual(resolvedComponents.first!.providersByType["[[A]]"]!.count, 2)
+        XCTAssertEqual(resolvedComponents.first!.providersByType[TypeKey(type: "[A]")]!.count, 2)
+        XCTAssertEqual(resolvedComponents.first!.providersByType[TypeKey(type: "[[A]]")]!.count, 2)
     }
     
     func testInvalidCollectionBindings() {
@@ -336,7 +332,7 @@ class ResolverTests: XCTestCase {
         let resolvedComponents = Resolver.resolve(interface: interface)
         XCTAssertEqual(resolvedComponents.count, 1)
         XCTAssertEqual(resolvedComponents.first!.diagnostics.count, 0)
-        XCTAssertNotNil(resolvedComponents.first!.providersByType["TaggedProvider<MyTag>"])
+        XCTAssertNotNil(resolvedComponents.first!.providersByType[TypeKey(type: "TaggedProvider<MyTag>")])
     }
     
     func testBasicCyclicalDependency() {
@@ -355,7 +351,7 @@ class ResolverTests: XCTestCase {
         let interface = LinkedInterface(components: [component], modules: [])
         let resolved = Resolver.resolve(interface: interface)
         XCTAssertEqual(resolved.count, 1)
-        XCTAssertEqual(resolved.first!.diagnostics.first!, ResolutionError(type: .cyclicalDependency(chain: ["DepA", "DepB", "DepA"])))
+        XCTAssertEqual(resolved.first!.diagnostics.first!, ResolutionError(type: .cyclicalDependency(chain: [TypeKey(type: "DepA"), TypeKey(type: "DepB"), TypeKey(type: "DepA")])))
     }
     
     func testThreeNCyclicalDependency() {
@@ -375,7 +371,7 @@ class ResolverTests: XCTestCase {
         let interface = LinkedInterface(components: [component], modules: [])
         let resolved = Resolver.resolve(interface: interface)
         XCTAssertEqual(resolved.count, 1)
-        XCTAssertEqual(resolved.first!.diagnostics.first!, ResolutionError(type: .cyclicalDependency(chain: ["DepA", "DepB", "DepC", "DepA"])))
+        XCTAssertEqual(resolved.first!.diagnostics.first!, ResolutionError(type: .cyclicalDependency(chain: [TypeKey(type: "DepA"), TypeKey(type: "DepB"), TypeKey(type: "DepC"), TypeKey(type: "DepA")])))
     }
     
     func testMultipleCyclicalDependency() {
@@ -398,8 +394,8 @@ class ResolverTests: XCTestCase {
         let resolved = Resolver.resolve(interface: interface)
         XCTAssertEqual(resolved.count, 1)
         XCTAssertEqual(resolved.first!.diagnostics.count, 2)
-        XCTAssertEqual(resolved.first!.diagnostics.first!, ResolutionError(type: .cyclicalDependency(chain: ["DepB", "DepC", "DepB"])))
-        XCTAssertEqual(resolved.first!.diagnostics[1], ResolutionError(type: .cyclicalDependency(chain: ["DepD", "DepE", "DepD"])))
+        XCTAssertEqual(resolved.first!.diagnostics.first!, ResolutionError(type: .cyclicalDependency(chain: [TypeKey(type: "DepB"), TypeKey(type: "DepC"), TypeKey(type: "DepB")])))
+        XCTAssertEqual(resolved.first!.diagnostics[1], ResolutionError(type: .cyclicalDependency(chain: [TypeKey(type: "DepD"), TypeKey(type: "DepE"), TypeKey(type: "DepD")])))
     }
     
     func testResolvesTaggedProviders() {
@@ -417,6 +413,6 @@ class ResolverTests: XCTestCase {
         let resolved = Resolver.resolve(interface: interface)
         XCTAssertEqual(resolved.count, 1)
         XCTAssertEqual(resolved.first!.diagnostics.count, 1)
-        XCTAssertEqual(resolved.first!.diagnostics.first!, ResolutionError(type: .missingProvider(dependency: "DepA", dependedUpon: rootA.mapToCanonical())))
+        XCTAssertEqual(resolved.first!.diagnostics.first!, ResolutionError(type: .missingProvider(dependency: TypeKey(type: "DepA"), dependedUpon: rootA.mapToCanonical())))
     }
 }

--- a/cleansec/cleansec.xcodeproj/project.pbxproj
+++ b/cleansec/cleansec.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		DC27A0C824D49C8800D37708 /* TypeKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC27A0C724D49C8800D37708 /* TypeKey.swift */; };
 		DC7CDDDC24B68A20003A1221 /* BasicBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7CDDDB24B68A20003A1221 /* BasicBindings.swift */; };
 		DC7CE83A24B77431003A1221 /* ComponentWithSeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7CE83924B77431003A1221 /* ComponentWithSeed.swift */; };
 		DC8497C0246A1D1600E704D6 /* Cleansec_Generate_Fixtures.h in Headers */ = {isa = PBXBuildFile; fileRef = DC8497BE246A1D1600E704D6 /* Cleansec_Generate_Fixtures.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -175,6 +176,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		DC27A0C724D49C8800D37708 /* TypeKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeKey.swift; sourceTree = "<group>"; };
 		DC7CDDDB24B68A20003A1221 /* BasicBindings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicBindings.swift; sourceTree = "<group>"; };
 		DC7CE83924B77431003A1221 /* ComponentWithSeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentWithSeed.swift; sourceTree = "<group>"; };
 		DC8497BC246A1D1600E704D6 /* Cleansec_Generate_Fixtures.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Cleansec_Generate_Fixtures.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -497,6 +499,7 @@
 				DC9966FD246C60EE0015B473 /* CanonicalProvider.swift */,
 				DC996700246C75740015B473 /* ResolvedComponent.swift */,
 				DCD305E7247736BC00CDD7B1 /* LinkedMerging.swift */,
+				DC27A0C724D49C8800D37708 /* TypeKey.swift */,
 			);
 			path = Resolver;
 			sourceTree = "<group>";
@@ -920,6 +923,7 @@
 				DCD305E8247736BC00CDD7B1 /* LinkedMerging.swift in Sources */,
 				DC9966F0246B5F4D0015B473 /* LinkedInterface.swift in Sources */,
 				DC849821246B2FEB00E704D6 /* ComponentRootProviderVisitor.swift in Sources */,
+				DC27A0C824D49C8800D37708 /* TypeKey.swift in Sources */,
 				DC9966EE246B5F280015B473 /* LinkedComponent.swift in Sources */,
 				DC84981B246B249D00E704D6 /* ProviderBuilders.swift in Sources */,
 				DC849808246B050F00E704D6 /* FileVisitor.swift in Sources */,


### PR DESCRIPTION
* First improvement is adding a `TypeKey` value type to normalize types.

Cleanse has a type of one-to-many mapping for a given dependency to how it can be used within the object graph. For a given `Type`, it can be represented as `Provider<Type>`, `WeakProvider<Type>`, or `() -> Type`. Currently we support this by adding each of these types into the object graph dictionary for key lookup during dependency resolution. However, for other resolution steps (i.e duplicate binding, cyclical dependencies), we filter these types out so that we don't over-report errors or run into false-positive. The `TypeKey` helps normalize the types we see in the graph so that we don't have to unnecessarily add and filter certain types during resolution.

* Refactors resolution functions into their primary operating type.

Most steps are just static functions with the primary operating type passed in as a parameter. We can make this a bit more "swifty" by moving the code into an extension on these types.