### PR TITLE
[cleansec] Sanitize -dump-ast spaced newlines.

### DIFF
--- a/cleansec/SwiftAstParser/Parsing/ASTStringHelpers.swift
+++ b/cleansec/SwiftAstParser/Parsing/ASTStringHelpers.swift
@@ -16,6 +16,10 @@ extension String {
             return false
         }
     }
+    
+    var isOnlyWhitespace: Bool {
+        allSatisfy { $0.isWhitespace }
+    }
 }
 
 extension String {

--- a/cleansec/SwiftAstParserTests/SanitizerTests.swift
+++ b/cleansec/SwiftAstParserTests/SanitizerTests.swift
@@ -57,4 +57,11 @@ class SanitizerTests: XCTestCase {
         let fixtureF = "  (something_cool  "
         XCTAssertEqual(fixtureF.isValidNewlineStart, true)
     }
+    
+    func testSpacesNewLine() {
+        let fixture = "(source_file)\n  (node)\n  \n  (node))"
+        let result = SyntaxParser.parse(text: fixture)
+        XCTAssert(result.count == 1)
+        XCTAssert(result.first!.children.count == 1)
+    }
 }


### PR DESCRIPTION
Some `-dump-ast` outputs have an irregularity where particular nodes have incorrect indentation, thus causing to be grouped under the wrong parent. This irregularity materializes as a newline with only `n` whitespace characters that should be prepended to the following line.

This change modifies `sanitize(lines:)` to account for this possibility. Introduces a helper `flatMapScanPrevious` which allows for scanning the previous element within `flatMap`.