### PR TITLE
Add suggested modules to "Missing Provider" errors.

### DIFF
--- a/cleansec/CleansecFramework/Cleansec.swift
+++ b/cleansec/CleansecFramework/Cleansec.swift
@@ -62,7 +62,7 @@ public struct CleansecError: CustomStringConvertible, Error {
     }
     
     public var description: String {
-        resolutionErrors.map { $0.description }.joined(separator: "\n")
+        resolutionErrors.map { $0.description }.joined(separator: "\n") + "\n"
     }
 }
 

--- a/cleansec/CleansecFrameworkTests/ResolutionErrorFormatTests.swift
+++ b/cleansec/CleansecFrameworkTests/ResolutionErrorFormatTests.swift
@@ -1,0 +1,77 @@
+//
+//  ResolutionErrorFormatTests.swift
+//  CleansecFrameworkTests
+//
+//  Created by Sebastian Edward Shanus on 8/20/20.
+//  Copyright © 2020 Square. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import CleansecFramework
+
+final class ResolutionErrorFormatTests: XCTestCase {
+    func testResolutionErrorWithSuggestion() {
+        let message = """
+    error: Missing Provider: 'B'
+    Depended upon by: 'Provider<A>'
+    note: Found in 'Pony'. Perhaps 'binder.include(module: Pony.self)'
+
+    """
+        let provider = CanonicalProvider(type: TypeKey(type: "A"), dependencies: [], isCollectionProvider: false, debugData: .empty)
+        let error = ResolutionError(type: .missingProvider(dependency: TypeKey(type: "B"), dependedUpon: provider, suggestedModules: ["Pony"]))
+        XCTAssertEqual(error.description, message)
+    }
+    
+    func testResolutionError() {
+        let message = """
+    error: Missing Provider: 'B'
+    Depended upon by: 'Provider<A>'
+
+    """
+        let provider = CanonicalProvider(type: TypeKey(type: "A"), dependencies: [], isCollectionProvider: false, debugData: .empty)
+        let error = ResolutionError(type: .missingProvider(dependency: TypeKey(type: "B"), dependedUpon: provider))
+        XCTAssertEqual(error.description, message)
+    }
+    
+    func testResolutionErrorDebugData() {
+        let message = """
+    /Users/Superfile.swift:123: error: Missing Provider: 'B'
+    Depended upon by: 'Provider<A>'
+
+    """
+        let provider = CanonicalProvider(type: TypeKey(type: "A"), dependencies: [], isCollectionProvider: false, debugData: .location("/Users/Superfile.swift:123"))
+        let error = ResolutionError(type: .missingProvider(dependency: TypeKey(type: "B"), dependedUpon: provider))
+        XCTAssertEqual(error.description, message)
+    }
+    
+    func testMissingInstalledComponentError() {
+        let message = """
+    error: Missing installed Component: 'Subby'
+
+    """
+        let error = ResolutionError(type: .missingSubcomponent("Subby"))
+        XCTAssertEqual(error.description, message)
+    }
+    
+    func testMissingIncludedModuleError() {
+        let message = """
+    error: Missing included Module: 'Moddy'
+
+    """
+        let error = ResolutionError(type: .missingModule("Moddy"))
+        XCTAssertEqual(error.description, message)
+    }
+    
+    func testDuplicateProviderError() {
+        let provider1 = StandardProvider(type: "A", dependencies: [], tag: nil, scoped: nil, collectionType: nil).mapToCanonical()
+        let provider2 = CanonicalProvider(type: TypeKey(type: "A"), dependencies: [], isCollectionProvider: false, debugData: .location("Users/SuperFile.swift:123"))
+        let message = """
+    error: Duplicate binding for 'Provider<A>'
+    Users/SuperFile.swift:123: note: 'Provider<A>' previously bound here.
+
+    """
+        let error = ResolutionError(type: .duplicateProvider([provider1, provider2]))
+        XCTAssertEqual(error.description, message)
+    }
+}

--- a/cleansec/CleansecFrameworkTests/ResolverTests.swift
+++ b/cleansec/CleansecFrameworkTests/ResolverTests.swift
@@ -415,4 +415,16 @@ class ResolverTests: XCTestCase {
         XCTAssertEqual(resolved.first!.diagnostics.count, 1)
         XCTAssertEqual(resolved.first!.diagnostics.first!, ResolutionError(type: .missingProvider(dependency: TypeKey(type: "DepA"), dependedUpon: rootA.mapToCanonical())))
     }
+    
+    func testSuggestedModules() {
+        let providerA = StandardProvider(type: "A", dependencies: [], tag: nil, scoped: nil, collectionType: nil)
+        let moduleA = LinkedModule(type: "AModule", providers: [providerA], includedModules: [], subcomponents: [])
+        
+        let providerB = StandardProvider(type: "B", dependencies: ["A"], tag: nil, scoped: nil, collectionType: nil)
+        let component = LinkedComponent(type: "MyComponent", rootType: "B", providers: [providerB], seed: "Void", includedModules: [], subcomponents: [], isRoot: true)
+        let interface = LinkedInterface(components: [component], modules: [moduleA])
+        let resolved = Resolver.resolve(interface: interface)
+        XCTAssertEqual(resolved.count, 1)
+        XCTAssertEqual(resolved.first!.diagnostics, [ResolutionError(type: .missingProvider(dependency: TypeKey(type: "A"), dependedUpon: providerB.mapToCanonical(), suggestedModules: ["AModule"]))])
+    }
 }

--- a/cleansec/cleansec.xcodeproj/project.pbxproj
+++ b/cleansec/cleansec.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		DC27A0C824D49C8800D37708 /* TypeKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC27A0C724D49C8800D37708 /* TypeKey.swift */; };
+		DC6B09A424EF4DB9000D2701 /* ResolutionErrorFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6B09A324EF4DB9000D2701 /* ResolutionErrorFormatTests.swift */; };
 		DC7CDDDC24B68A20003A1221 /* BasicBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7CDDDB24B68A20003A1221 /* BasicBindings.swift */; };
 		DC7CE83A24B77431003A1221 /* ComponentWithSeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7CE83924B77431003A1221 /* ComponentWithSeed.swift */; };
 		DC8497C0246A1D1600E704D6 /* Cleansec_Generate_Fixtures.h in Headers */ = {isa = PBXBuildFile; fileRef = DC8497BE246A1D1600E704D6 /* Cleansec_Generate_Fixtures.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -178,6 +179,7 @@
 
 /* Begin PBXFileReference section */
 		DC27A0C724D49C8800D37708 /* TypeKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeKey.swift; sourceTree = "<group>"; };
+		DC6B09A324EF4DB9000D2701 /* ResolutionErrorFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolutionErrorFormatTests.swift; sourceTree = "<group>"; };
 		DC7CDDDB24B68A20003A1221 /* BasicBindings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicBindings.swift; sourceTree = "<group>"; };
 		DC7CE83924B77431003A1221 /* ComponentWithSeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentWithSeed.swift; sourceTree = "<group>"; };
 		DC8497BC246A1D1600E704D6 /* Cleansec_Generate_Fixtures.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Cleansec_Generate_Fixtures.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -530,6 +532,7 @@
 				DC9966F3246B63350015B473 /* LinkerTests.swift */,
 				DC996704246C7C700015B473 /* ResolverTests.swift */,
 				DCF196502472F3580057BDC5 /* PluginTests.swift */,
+				DC6B09A324EF4DB9000D2701 /* ResolutionErrorFormatTests.swift */,
 			);
 			path = CleansecFrameworkTests;
 			sourceTree = "<group>";
@@ -957,6 +960,7 @@
 				DC996705246C7C700015B473 /* ResolverTests.swift in Sources */,
 				DCF196512472F3580057BDC5 /* PluginTests.swift in Sources */,
 				DCD3334C2469B3AB008B053F /* FileVisitorTests.swift in Sources */,
+				DC6B09A424EF4DB9000D2701 /* ResolutionErrorFormatTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
* If one has a missing provider and has compiled a `Cleanse.Module` that `cleansec` parses from the search paths to include that particular provider, we will include a note below the error message with a list of suggested modules they might wish to include.

Depending on the user's search path for parsed modules, it's possible that the suggested module could be stale and not have been _actually_ compiled/updated. This will likely occur if the output path for all cleansec modules is the same. Considering this is merely a suggestion to help guide the user towards finding their module, this edge case doesn't pose too much of an issue.

* Added `ResolutionErrorFormatTests` to add coverage for the emitted error description that goes to `stderr` that Xcode parses.