### PR TITLE
Compile Cleanse project using XC 12.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: macos-latest
     env:
-      DEVELOPER_DIR: /Applications/Xcode_11.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_12.app/Contents/Developer
     steps:
     - uses: actions/checkout@v2
     - name: Test

--- a/CleanseTests/CleanseTests.swift
+++ b/CleanseTests/CleanseTests.swift
@@ -90,8 +90,8 @@ struct APIComponent : RootComponent {
 struct BurgerModule : Module {
     static func configure(binder: Binder<Singleton>) {
         binder.bind().to(factory: Burger.init)
-        binder.bind().to { return Cheese.cheddar }
-        binder.bind().to { Roll.ciabatta }
+        binder.bind().to(value: Cheese.cheddar)
+        binder.bind().to(value: Roll.ciabatta)
         
         var singletonCountTest = 1
         binder

--- a/CleanseTests/MemoryManagementTests.swift
+++ b/CleanseTests/MemoryManagementTests.swift
@@ -82,9 +82,9 @@ class MemoryManagementTests: XCTestCase {
             binder.bind().sharedInScope().to(factory: Single2.init)
             binder.bind().sharedInScope().to(factory: SingleStruct1.init)
             
-            binder.bind().intoCollection().sharedInScope().to { SingleCollectionElement(value: 3) }
-            binder.bind().intoCollection().sharedInScope().to { SingleCollectionElement(value: 4) }
-            binder.bind().intoCollection().sharedInScope().to { SingleCollectionElement(value: 5) }
+            binder.bind().intoCollection().sharedInScope().to(value: SingleCollectionElement(value: 3))
+            binder.bind().intoCollection().sharedInScope().to(value:  SingleCollectionElement(value: 4) )
+            binder.bind().intoCollection().sharedInScope().to(value: SingleCollectionElement(value: 5))
         }
     }
     

--- a/Examples/CleanseGithubBrowser/CleanseGithubBrowser/NetworkModule.swift
+++ b/Examples/CleanseGithubBrowser/CleanseGithubBrowser/NetworkModule.swift
@@ -16,7 +16,7 @@ struct NetworkModule : Module {
         binder
             .bind()
             .sharedInScope()
-            .to { URLSessionConfiguration.ephemeral }
+            .to(value: URLSessionConfiguration.ephemeral)
 
         binder
             .bind(URLSession.self)


### PR DESCRIPTION
Addresses issue #171. More info about why we had to disambiguate between the 0-th arity `factory` function and the `value` function is described in the issue.